### PR TITLE
allow iodata as the response body

### DIFF
--- a/lib/plug/connection.ex
+++ b/lib/plug/connection.ex
@@ -21,7 +21,7 @@ defrecord Plug.Conn,
 
   @type adapter      :: { module, term }
   @type assigns      :: Keyword.t
-  @type body         :: binary
+  @type body         :: iodata
   @type cookies      :: [{ binary, binary }]
   @type headers      :: [{ binary, binary }]
   @type host         :: binary
@@ -248,7 +248,7 @@ defmodule Plug.Connection do
     end
   end
 
-  def chunk(Conn[], chunk) when is_binary(chunk) do
+  def chunk(Conn[], chunk) when is_binary(chunk) or is_list(chunk) do
     raise ArgumentError, message: "chunk/2 expects a chunked response. Please ensure " <>
                                   "you have called send_chunked/2 before you send a chunk"
   end
@@ -259,7 +259,8 @@ defmodule Plug.Connection do
   See `send_resp/1` for more information.
   """
   @spec send_resp(Conn.t, Conn.status, Conn.body) :: Conn.t | no_return
-  def send_resp(Conn[] = conn, status, body) when is_integer(status) and is_binary(body) do
+  def send_resp(Conn[] = conn, status, body)
+      when is_integer(status) and (is_binary(body) or is_list(body)) do
     conn |> resp(status, body) |> send_resp()
   end
 
@@ -271,11 +272,13 @@ defmodule Plug.Connection do
   """
   @spec resp(Conn.t, Conn.status, Conn.body) :: Conn.t
   def resp(Conn[state: state] = conn, status, body)
-      when is_integer(status) and is_binary(body) and state in [:unset, :set] do
+      when is_integer(status) and state in [:unset, :set]
+        and (is_binary(body) or is_list(body)) do
     conn.status(status).resp_body(body).state(:set)
   end
 
-  def resp(Conn[], status, body) when is_integer(status) and is_binary(body) do
+  def resp(Conn[], status, body)
+      when is_integer(status) and (is_binary(body) or is_list(body)) do
     raise AlreadySentError
   end
 

--- a/test/plug/connection_test.exs
+++ b/test/plug/connection_test.exs
@@ -87,6 +87,11 @@ defmodule Plug.ConnectionTest do
     end
   end
 
+  test "send_resp/3 allows for iolist in the resp body" do
+    conn(:get, "/foo") |> send_resp(200, ["this ", ["is", " nested"]])
+    assert_received { :plug_conn, :sent }
+  end
+
   test "send_file/3" do
     conn = conn(:get, "/foo") |> send_file(200, __ENV__.file)
     assert conn.status == 200


### PR DESCRIPTION
Hi Jose

I asked few days ago on irc (nick hnc) for a way to pass iolist-formed bodies via Plug.Conn.send_resp/3 to Cowboy. Well I checked it an Cowboy allows passing iolists - please see cowboy_req:reply/4 at https://github.com/extend/cowboy/blob/master/src/cowboy_req.erl#L1009

So here's the Plug patch, I tested it with my webserver heavily using iolists, works fine.

Best,
Wojtek
