### PR TITLE
Elli adapter

### DIFF
--- a/lib/plug/adapters/elli.ex
+++ b/lib/plug/adapters/elli.ex
@@ -1,0 +1,65 @@
+defmodule Plug.Adapters.Elli do
+  @moduledoc """
+  Adapter interface to the Elli webserver
+
+  ## Options
+
+  * `:ip` - the ip to bind the server to.
+            Must be a tuple in the format `{ x, y, z, w }`.
+
+  * `:port` - the port to run the server.
+              Defaults to 4000 (http) and 4040 (https).
+
+  * `:min_acceptors` - the minimum number of acceptors for the listener.
+                       Defaults to 20.
+
+  * `:max_body_size` - The maximum allowed body size in bytes of a
+                       request. Defaults to 10MB.
+
+  * `:ref` - the reference name to be used. Defaults to `plug.HTTP`.
+             This is the value that needs to be given on shutdown.
+
+  """
+
+  alias Plug.Adapters.Elli.Supervisor
+
+  @doc """
+  Runs Elli under http.
+
+  ## Example
+
+      # Starts a new interface
+      Plug.Adapters.Elli.http MyPlug, [], port: 80
+
+      # The interface above can be shutdown with
+      Plug.Adapters.Elli.shutdown MyPlug.HTTP
+
+  """
+  def http(plug, opts, options // []) do
+    case Supervisor.start_link do
+      { :ok, _pid } ->
+        start_elli(plug, opts, options)
+      { :error, { :already_started, _pid } } ->
+        start_elli(plug, opts, options)
+      error ->
+        error
+    end
+  end
+
+  @doc """
+  Shutdowns the given reference. If you have a plug `MyPlug`,
+  the default reference is `MyPlug.HTTP`.
+  """
+  def shutdown(ref) do
+    Supervisor.stop_elli(ref)
+  end
+
+  defp start_elli(plug, opts, options) do
+      ref = Module.concat(plug, HTTP)
+      handler = [callback: Plug.Adapters.Elli.Handler,
+                 callback_args: { plug, opts }]
+      options = Keyword.put_new(options, :port, 4000)
+                |> Keyword.merge(handler)
+      Supervisor.start_elli(ref, options)
+  end
+end

--- a/lib/plug/adapters/elli/connection.ex
+++ b/lib/plug/adapters/elli/connection.ex
@@ -40,6 +40,10 @@ defmodule Plug.Adapters.Elli.Connection do
     R.send_chunk(R.chunk_ref(req), body)
   end
 
+  # Elli actually always fetches the complete body before executing any handler,
+  # so this implementation merely exists for compatibility purposes.
+  # Also note that a request with a body exceeding the maximum body size specified in
+  # Elli's startup options will be discarded before executing any handler.
   def stream_req_body(req, limit) do
     body = R.body(req)
     if body == :done do

--- a/lib/plug/adapters/elli/connection.ex
+++ b/lib/plug/adapters/elli/connection.ex
@@ -78,7 +78,7 @@ defmodule Plug.Adapters.Elli.Connection do
   defp send_to_elli(resp, req) do
     # Although the name is confusing, chunk_ref just returns
     # the pid of the Elli process that executes the Elli handler.
-    R.chunk_ref(req) <- { :plug_response, resp }
+    send(R.chunk_ref(req), { :plug_response, resp })
     receive do
       { :elli_handler, result } -> result
     after

--- a/lib/plug/adapters/elli/connection.ex
+++ b/lib/plug/adapters/elli/connection.ex
@@ -1,0 +1,62 @@
+defmodule Plug.Adapters.Elli.Connection do
+  @behaviour Plug.Connection.Adapter
+  @moduledoc false
+
+  require :elli_request, as: R
+
+  def conn(req) do
+    { host, port } = split_host_header(R.get_header("Host", req))
+    headers  = downcase_fields(R.headers(req))
+    Plug.Conn[
+      adapter: { __MODULE__, req },
+      host: host,
+      method: to_string(R.method(req)),
+      path_info: R.path(req),
+      port: port,
+      query_string: R.query_str(req),
+      req_headers: headers,
+      scheme: :http
+    ]
+  end
+
+  def send_resp(req, status, headers, body) do
+    resp = { status, headers, body }
+    { :ok, resp, req }
+  end
+
+  def send_file(req, status, headers, path) do
+    resp = { status, [{ "content-length", :elli_util.file_size(path) } | headers], { :file, path } }
+    { :ok, resp, req }
+  end
+
+  def send_chunked(req, _status, headers) do
+    resp = { :chunk, headers }
+    { :ok, resp, req }
+  end
+
+  def chunk(req, body) do
+    R.send_chunk(R.chunk_ref(req), body)
+  end
+
+  def stream_req_body(_req, _limit) do
+    raise UndefinedFunctionError, message: "Streaming of body data is not implemented for the Elli adapter."
+  end
+
+  def parse_req_multipart(_req, _limit, _callback) do
+    raise UndefinedFunctionError, message: "Multipart parsing is not implemented for the Elli adapter."
+  end
+
+  ## Helpers
+
+  defp split_host_header(h) do
+    case :binary.split(h, ":") do
+      [host, port] -> { host, binary_to_integer(port) }
+      [host] -> { host, 80 }
+    end
+  end
+
+  defp downcase_fields(headers) do
+    lc { field, value } inlist headers, do: { String.downcase(field), value }
+  end
+
+end

--- a/lib/plug/adapters/elli/handler.ex
+++ b/lib/plug/adapters/elli/handler.ex
@@ -1,0 +1,22 @@
+defmodule Plug.Adapters.Elli.Handler do
+  @behaviour :elli_handler
+  @moduledoc false
+
+  @connection Plug.Adapters.Elli.Connection
+
+
+  def handle(req, { plug, opts }) do
+    case plug.call(@connection.conn(req), opts) do
+      { stat, Plug.Conn[adapter: { @connection, req }, resp_body: resp, state: state] } when stat in [:ok, :halt] ->
+        if nil?(resp), do: { 204, [], "" }, else: resp
+      other ->
+        raise "the Elli adapter expected a plug to return { :ok, conn } " <>
+              "or { :halt, conn }, instead we got: #{inspect other}"
+    end
+  end
+
+  def handle_event(_type, _args, _) do
+    :ok
+  end
+
+end

--- a/lib/plug/adapters/elli/handler.ex
+++ b/lib/plug/adapters/elli/handler.ex
@@ -6,17 +6,51 @@ defmodule Plug.Adapters.Elli.Handler do
 
 
   def handle(req, { plug, opts }) do
+    pid = spawn_link(__MODULE__, :plug_handler, [req, plug, opts])
+    # Put the pid in the process dictionary so that when the request is completed,
+    # a response can be send back to the plug handler from handle_event/3.
+    Process.put(:plug_pid, pid)
+    receive do
+      { :plug_response, resp } ->
+        if elem(resp, 0) == :chunk do
+          # If a chunked response is requested from the plug handler,
+          # respond immediately, because Elli doesn't emit a
+          # :request_complete event with chunked transfers.
+          pid <- { :elli_handler, :ok }
+        end           
+        resp
+    end
+  end
+
+  @response_events [:request_complete, :client_closed, :file_error,
+                    :request_throw, :request_error, :request_exit]
+
+  def handle_event(type, _args, _) when type in @response_events do
+    Process.get(:plug_pid) <- { :elli_handler, to_result(type) }
+    :ok
+  end
+  def handle_event(_type, _args, _) do
+    :ok
+  end
+
+  @doc false
+  def plug_handler(req, plug, opts) do
     case plug.call(@connection.conn(req), opts) do
-      { stat, Plug.Conn[adapter: { @connection, req }, resp_body: resp, state: state] } when stat in [:ok, :halt] ->
-        if nil?(resp), do: { 204, [], "" }, else: resp
+      { stat, Plug.Conn[adapter: { @connection, _req }, state: state] = conn } when stat in [:ok, :halt] ->
+        cond do
+          state in [:set, :unset] ->
+            Plug.Connection.send(conn, 204, "")
+          state == :chunked ->
+            Plug.Connection.chunk(conn, "")
+          true -> nil
+        end
       other ->
         raise "the Elli adapter expected a plug to return { :ok, conn } " <>
               "or { :halt, conn }, instead we got: #{inspect other}"
     end
   end
 
-  def handle_event(_type, _args, _) do
-    :ok
-  end
+  defp to_result(:request_complete), do: :ok
+  defp to_result(error), do: { :error, error }
 
 end

--- a/lib/plug/adapters/elli/handler.ex
+++ b/lib/plug/adapters/elli/handler.ex
@@ -17,7 +17,7 @@ defmodule Plug.Adapters.Elli.Handler do
           # respond immediately, because Elli doesn't emit a
           # :request_complete event with chunked transfers.
           send(pid, { :elli_handler, :ok })
-        end           
+        end
         resp
     end
   end
@@ -33,7 +33,6 @@ defmodule Plug.Adapters.Elli.Handler do
     :ok
   end
 
-  @doc false
   def plug_handler(req, plug, opts) do
     case plug.call(@connection.conn(req), opts) do
       { stat, Plug.Conn[adapter: { @connection, _req }, state: state] = conn } when stat in [:ok, :halt] ->

--- a/lib/plug/adapters/elli/supervisor.ex
+++ b/lib/plug/adapters/elli/supervisor.ex
@@ -12,13 +12,7 @@ defmodule Plug.Adapters.Elli.Supervisor do
   end
 
   def start_elli(ref, options) do
-    case :supervisor.start_child(__MODULE__, worker(:elli, [options], [id: ref])) do
-      { :ok, _ } ->
-        { :ok, ref }
-      { :error, { :already_started, _ } } ->
-        { :error, { :already_started, ref } }
-      other_error -> other_error
-    end
+    :supervisor.start_child(__MODULE__, worker(:elli, [options], [id: ref]))
   end
 
   def stop_elli(ref) do

--- a/lib/plug/adapters/elli/supervisor.ex
+++ b/lib/plug/adapters/elli/supervisor.ex
@@ -1,0 +1,30 @@
+defmodule Plug.Adapters.Elli.Supervisor do
+
+  @moduledoc false
+  use Supervisor.Behaviour
+
+  def start_link do
+    :supervisor.start_link({ :local, __MODULE__ }, __MODULE__, [])
+  end
+
+  def init([]) do
+    supervise([], strategy: :one_for_one)
+  end
+
+  def start_elli(ref, options) do
+    case :supervisor.start_child(__MODULE__, worker(:elli, [options], [id: ref])) do
+      { :ok, _ } ->
+        { :ok, ref }
+      { :error, { :already_started, _ } } ->
+        { :error, { :already_started, ref } }
+      other_error -> other_error
+    end
+  end
+
+  def stop_elli(ref) do
+    case :supervisor.terminate_child(__MODULE__, ref) do
+      :ok -> :supervisor.delete_child(__MODULE__, ref)
+      error -> error
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,8 @@ defmodule Plug.Mixfile do
   end
 
   def deps(:prod) do
-    [ { :cowboy, "~> 0.9", github: "extend/cowboy", optional: true } ]
+    [ { :cowboy, "~> 0.9", github: "extend/cowboy", optional: true },
+      { :elli, "~> 0.4.1", github: "knutin/elli", optional: true } ]
   end
 
   def deps(:docs) do

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 [ "cowboy": {:git, "git://github.com/extend/cowboy.git", "5a25c7f7f2167b8cef03129553e56f422a9890f2", []},
   "cowlib": {:git, "git://github.com/extend/cowlib.git", "63298e8e160031a70efff86a1acde7e7db1fcda6", [{:ref, "0.4.0"}]},
+  "elli": {:git, "git://github.com/knutin/elli.git", "47396a92d256f6ad20f76381a2fb236753aa157e", []},
   "ex_doc": {:git, "git://github.com/elixir-lang/ex_doc.git", "a5ff9956feeea113509125e5b29623c1fa7e3be4", []},
   "hackney": {:git, "git://github.com/benoitc/hackney.git", "476b4992c64873ed67bf6daa5c48f0a31c2435b8", []},
   "mimetypes": {:git, "https://github.com/spawngrid/mimetypes.git", "47d37a977a7d633199822bf6b08353007483d00f", [{:ref, "master"}]},

--- a/test/plug/adapters/elli/connection_test.exs
+++ b/test/plug/adapters/elli/connection_test.exs
@@ -1,0 +1,153 @@
+defmodule Plug.Adapters.Elli.ConnectionTest do
+  use ExUnit.Case, async: true
+
+  alias  Plug.Conn
+  import Plug.Connection
+
+  ## Elli setup for testing
+
+  setup_all do
+    { :ok, _pid } = Plug.Adapters.Elli.http __MODULE__, [], port: 8003
+    :ok
+  end
+
+  teardown_all do
+    :ok = Plug.Adapters.Elli.shutdown(__MODULE__.HTTP)
+  end
+
+  def call(conn, []) do
+    function = binary_to_atom Enum.first(conn.path_info) || "root"
+    apply __MODULE__, function, [conn]
+  rescue
+    exception ->
+      receive do
+        { :plug_conn, :sent } ->
+          :erlang.raise(:error, exception, :erlang.get_stacktrace)
+      after
+        0 ->
+send          { :halt, send(conn, 500, exception.message <> "\n" <>
+                        Exception.format_stacktrace(System.stacktrace)) }
+      end
+  end
+
+  ## Tests
+
+  def root(Conn[] = conn) do
+    assert conn.method == "HEAD"
+    assert conn.path_info == []
+    assert conn.query_string == "foo=bar&baz=bat"
+    { :ok, conn }
+  end
+
+  def build(Conn[] = conn) do
+    assert { Plug.Adapters.Elli.Connection, _ } = conn.adapter
+    assert conn.path_info == ["build", "foo", "bar"]
+    assert conn.query_string == ""
+    assert conn.scheme == :http
+    assert conn.host == "127.0.0.1"
+    assert conn.port == 8003
+    assert conn.method == "GET"
+    { :ok, conn }
+  end
+
+  test "builds a connection" do
+    assert { 204, _, _ } = request :head, "/?foo=bar&baz=bat"
+    assert { 204, _, _ } = request :get, "/build/foo/bar"
+    assert { 204, _, _ } = request :get, "//build//foo//bar"
+  end
+
+  def headers(conn) do
+    assert conn.req_headers["foo"] == "bar"
+    assert conn.req_headers["baz"] == "bat"
+    { :ok, conn }
+  end
+
+  test "stores request headers" do
+    assert { 204, _, _ } = request :get, "/headers", [{ "foo", "bar" }, { "baz", "bat" }]
+  end
+
+  def send_200(conn) do
+    assert conn.state == :unset
+    assert conn.resp_body == nil
+    conn = send(conn, 200, "OK")
+    assert conn.state == :sent
+
+    assert { 200, _headers, "OK" } = conn.resp_body
+    { :ok, conn }
+  end
+
+  def send_500(conn) do
+    { :ok, conn
+           |> delete_resp_header("cache-control")
+           |> put_resp_header("x-sample", "value")
+           |> send(500, "ERROR") }
+  end
+
+  test "sends a response with status, headers and body" do
+    assert { 200, headers, "OK" } = request :get, "/send_200"
+    assert headers["cache-control"] == "max-age=0, private, must-revalidate"
+    assert { 500, headers, "ERROR" } = request :get, "/send_500"
+    assert headers["cache-control"] == nil
+    assert headers["x-sample"] == "value"
+  end
+
+  test "skips body on head" do
+    assert { 200, _, "" } = request :head, "/send_200"
+  end
+
+  def send_file(conn) do
+    conn = send_file(conn, 200, __FILE__)
+    assert conn.state == :sent
+    assert { 200, _headers, { :file, __FILE__ } } = conn.resp_body
+    { :ok, conn }
+  end
+
+  test "sends a file with status and headers" do
+    assert { 200, headers, body } = request :get, "/send_file"
+    assert body =~ "sends a file with status and headers"
+    assert headers["cache-control"] == "max-age=0, private, must-revalidate"
+    assert headers["content-length"] == File.stat!(__FILE__).size |> integer_to_binary
+  end
+
+  test "skips file on head" do
+    assert { 200, _, "" } = request :head, "/send_file"
+  end
+
+  def send_chunked(conn) do
+    conn = send_chunked(conn, 200)
+    assert conn.state == :chunked
+    spawn(fn() -> __MODULE__.chunk_loop(conn) end)
+    { :ok, conn }
+  end
+
+  # Send 10 separate chunks to the client.
+
+  def chunk_loop(conn), do: chunk_loop(conn, 10)
+
+  def chunk_loop(conn, 0), do: chunk(conn, "")
+  def chunk_loop(conn, n) do
+    :timer.sleep(100)
+    case chunk(conn, to_string(n)) do
+      { :ok, conn } ->
+        chunk_loop(conn, n - 1)
+      { :error, reason } ->
+        IO.puts("error in sending chunk: #{inspect reason}")
+    end
+  end
+
+  test "sends a chunked response with status and headers" do
+    assert { 200, headers, "10987654321" } = request :get, "/send_chunked"
+    assert headers["cache-control"] == "max-age=0, private, must-revalidate"
+    assert headers["Transfer-Encoding"] == "chunked"
+  end
+
+  ## Helpers
+
+  defp request(verb, path, headers // [], body // "") do
+    { :ok, status, headers, client } =
+      :hackney.request(verb, "http://127.0.0.1:8003" <> path, headers, body, [])
+    { :ok, body, _ } = :hackney.body(client)
+    :hackney.close(client)
+    { status, headers, body }
+  end
+end

--- a/test/plug/adapters/elli/connection_test.exs
+++ b/test/plug/adapters/elli/connection_test.exs
@@ -16,7 +16,7 @@ defmodule Plug.Adapters.Elli.ConnectionTest do
   end
 
   def call(conn, []) do
-    function = binary_to_atom Enum.first(conn.path_info) || "root"
+    function = binary_to_atom List.first(conn.path_info) || "root"
     apply __MODULE__, function, [conn]
   rescue
     exception ->
@@ -25,7 +25,7 @@ defmodule Plug.Adapters.Elli.ConnectionTest do
           :erlang.raise(:error, exception, :erlang.get_stacktrace)
       after
         0 ->
-          { :halt, send(conn, 500, exception.message <> "\n" <>
+          { :halt, send_resp(conn, 500, exception.message <> "\n" <>
                         Exception.format_stacktrace(System.stacktrace)) }
       end
   end
@@ -69,7 +69,7 @@ defmodule Plug.Adapters.Elli.ConnectionTest do
   def send_200(conn) do
     assert conn.state == :unset
     assert conn.resp_body == nil
-    conn = send(conn, 200, "OK")
+    conn = send_resp(conn, 200, "OK")
     assert conn.state == :sent
     assert conn.resp_body == nil
     { :ok, conn }
@@ -79,7 +79,7 @@ defmodule Plug.Adapters.Elli.ConnectionTest do
     { :ok, conn
            |> delete_resp_header("cache-control")
            |> put_resp_header("x-sample", "value")
-           |> send(500, "ERROR") }
+           |> send_resp(500, "ERROR") }
   end
 
   test "sends a response with status, headers and body" do
@@ -95,7 +95,7 @@ defmodule Plug.Adapters.Elli.ConnectionTest do
   end
 
   def send_file(conn) do
-    conn = send_file(conn, 200, __FILE__)
+    conn = send_file(conn, 200, __ENV__.file)
     assert conn.state == :sent
     assert conn.resp_body == nil
     { :ok, conn }
@@ -103,9 +103,9 @@ defmodule Plug.Adapters.Elli.ConnectionTest do
 
   test "sends a file with status and headers" do
     assert { 200, headers, body } = request :get, "/send_file"
-    assert body =~ "sends a file with status and headers"
+    assert String.contains?(body, "sends a file with status and headers")
     assert headers["cache-control"] == "max-age=0, private, must-revalidate"
-    assert headers["content-length"] == File.stat!(__FILE__).size |> integer_to_binary
+    assert headers["content-length"] == File.stat!(__ENV__.file).size |> integer_to_binary
   end
 
   test "skips file on head" do


### PR DESCRIPTION
Elli works a bit differently than Cowboy and since Plug's adapter specification seems to be largely based on Cowboy, the Elli adapter needs to do some extra work to satisfy Plug's adapter expectations. A couple of things to note:
- Elli is not supervised out of the box, so the Elli adapter implements a simple supervisor.
- Except for chunked transfers, Elli only sends a response back to the client when a handler returns, so in order to allow Plug.Connection.send_resp and friends, Plug.Adapters.Elli.Handler spawns an extra process  that executes the Plug handler.
- Elli doesn't support streaming of request bodies, as it always fetches the complete body before executing any handler. This means that while Plug.Adapters.Elli.Connection.stream_req_body/2 perfectly works, it doesn't do any actual streaming, but just mimics cowboy's behaviour instead.
- One can only set a max request body at startup. If a request is made with a body that exceeds this size, the request is discarded without executing any handler.
- When using a pre OTP 17.0 rc1 version, an error can occur once in a while when running mix test because of a file:sendfile/5 bug in Erlang.

TODO: Examine error reporting more closely to see if the extra process spawning in the Elli adapter changes error reporting behaviour when a Plug handler crashes
