### PR TITLE
Add json parser

### DIFF
--- a/lib/plug/parsers/json.ex
+++ b/lib/plug/parsers/json.ex
@@ -1,0 +1,31 @@
+defmodule Plug.Parsers.JSON do
+  @moduledoc false
+  alias Plug.Conn
+
+  def parse(Conn[] = conn, "application", "json", _headers, opts) do
+    read_body(conn, Keyword.fetch!(opts, :limit))
+  end
+
+  def parse(conn, _type, _subtype, _headers, _opts) do
+    { :next, conn }
+  end
+
+  defp read_body(Conn[adapter: { adapter, state }] = conn, limit) do
+    case read_body({ :ok, "", state }, "", limit, adapter) do
+      { :too_large, state } ->
+        { :too_large, conn.adapter({ adapter, state }) }
+      { :ok, body, state } ->
+        { :ok, JSON.decode(body), conn.adapter({ adapter, state }) }
+    end
+  end
+
+  defp read_body({ :ok, buffer, state }, acc, limit, adapter) when limit >= 0,
+    do: read_body(adapter.stream_req_body(state, 1_000_000), acc <> buffer, limit - byte_size(buffer), adapter)
+  defp read_body({ :ok, _, state }, _acc, _limit, _adapter),
+    do: { :too_large, state }
+
+  defp read_body({ :done, state }, acc, limit, _adapter) when limit >= 0,
+    do: { :ok, acc, state }
+  defp read_body({ :done, state }, _acc, _limit, _adapter),
+    do: { :too_large, state }
+end

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,8 @@ defmodule Plug.Mixfile do
 
   def deps(:prod) do
     [ { :mime, github: "dynamo/mime" },
-      { :cowboy, "~> 0.9", github: "extend/cowboy", optional: true } ]
+      { :cowboy, "~> 0.9", github: "extend/cowboy", optional: true },
+      { :jsonex, "~> 0.1.1", github: 'devinus/jsonex' } ]
   end
 
   def deps(:docs) do

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,8 @@
   "cowlib": {:git, "git://github.com/extend/cowlib.git", "63298e8e160031a70efff86a1acde7e7db1fcda6", [ref: "0.4.0"]},
   "ex_doc": {:git, "git://github.com/elixir-lang/ex_doc.git", "dc0397d15686315dad653ed13c4836e4c6ef54e3", []},
   "hackney": {:git, "git://github.com/benoitc/hackney.git", "476b4992c64873ed67bf6daa5c48f0a31c2435b8", []},
+  "jsonex": {:git, "git://github.com/devinus/jsonex.git", "5795c1bc3d1bed1c2a379be415d0209fd076ef23", []},
+  "jsx": {:git, "git://github.com/talentdeficit/jsx.git", "9cb8703beecaf4c39e3dbfa293c747a0e7aa6450", []},
   "mime": {:git, "git://github.com/dynamo/mime.git", "db84370c53a67a7e58a4d0cfb026f4edc64a9367", []},
   "mimetypes": {:git, "https://github.com/spawngrid/mimetypes.git", "47d37a977a7d633199822bf6b08353007483d00f", [ref: "master"]},
   "ranch": {:git, "git://github.com/extend/ranch.git", "5df1f222f94e08abdcab7084f5e13027143cc222", [ref: "0.9.0"]} ]

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -4,7 +4,7 @@ defmodule Plug.ParsersTest do
   import Plug.Test
 
   def parse(conn, opts \\ []) do
-    opts = Keyword.put_new(opts, :parsers, [Plug.Parsers.URLENCODED, Plug.Parsers.MULTIPART])
+    opts = Keyword.put_new(opts, :parsers, [Plug.Parsers.URLENCODED, Plug.Parsers.MULTIPART, Plug.Parsers.JSON])
     Plug.Parsers.call(conn, Plug.Parsers.init(opts))
   end
 
@@ -27,6 +27,13 @@ defmodule Plug.ParsersTest do
 
   test "parses multipart bodies" do
     conn = parse(conn(:get, "/?foo=bar", [foo: "baz"]))
+    assert conn.params["foo"] == "baz"
+  end
+
+  test "parses json bodies" do
+    headers = [{ "content-type", "application/json" }]
+    json = JSON.encode( [ foo: "baz" ] )
+    conn = parse(conn(:get, "/?foo=bar", json, headers: headers ))
     assert conn.params["foo"] == "baz"
   end
 


### PR DESCRIPTION
Hi,
I added a simplistic module to parse json bodies using JsonEx. 

Unfortunately I don't know how to configure mix to regard JsonEx as an optional module and have Plug not use the json parser if JsonEx is not in the dependencies. Could you give me a hand there?

thanks!
