### PR TITLE
Add peer_ip and peer_port fields to Conn

### DIFF
--- a/lib/plug/adapters/cowboy/connection.ex
+++ b/lib/plug/adapters/cowboy/connection.ex
@@ -21,8 +21,7 @@ defmodule Plug.Adapters.Cowboy.Connection do
       method: meth,
       path_info: split_path(path),
       port: port,
-      peer_ip: peer_ip,
-      peer_port: peer_port,
+      peer: {peer_ip, peer_port},
       query_string: qs,
       req_headers: hdrs,
       scheme: scheme(transport)

--- a/lib/plug/connection.ex
+++ b/lib/plug/connection.ex
@@ -17,8 +17,7 @@ defrecord Plug.Conn,
     resp_body: nil,
     resp_cookies: [],
     resp_headers: [{"cache-control", "max-age=0, private, must-revalidate"}],
-    peer_ip: nil,
-    peer_port: nil,
+    peer: nil,
     scheme: nil,
     state: :unset,
     status: nil do
@@ -79,8 +78,7 @@ defrecord Plug.Conn,
   * `req_headers` - the request headers as a list, example: `[{ "content-type", "text/plain" }]`
   * `scheme` - the request scheme as an atom, example: `:http`
   * `query_string` - the request query string as a binary, example: `"foo=bar"`
-  * `peer_ip` - the request IP address, example: "60.145.144.120"
-  * `peer_port` - the request port, example: 80
+  * `peer` - the request IP address and port as a tuple, example: {"60.145.144.120", 80}
 
   ## Fetchable fields
 

--- a/test/plug/adapters/cowboy/connection_test.exs
+++ b/test/plug/adapters/cowboy/connection_test.exs
@@ -50,8 +50,8 @@ defmodule Plug.Adapters.Cowboy.ConnectionTest do
     assert conn.scheme == :http
     assert conn.host == "127.0.0.1"
     assert conn.port == 8001
-    assert conn.peer_ip == "127.0.0.1"
-    assert is_integer(conn.peer_port)
+    assert elem(conn.peer, 0) == "127.0.0.1"
+    assert is_integer(elem(conn.peer, 1))
     assert conn.method == "GET"
     conn
   end


### PR DESCRIPTION
This PR adds `peer_ip`, `peer_port` fields to the Conn. I wasn't sure how to get at the ranch/cowboy request to setup the peer_port, so the test for `peer_port` currently just asserts that it's a present and valid integer.
