### PR TITLE
Server-Sent Events

### DIFF
--- a/lib/plug/server_sent_event.ex
+++ b/lib/plug/server_sent_event.ex
@@ -1,0 +1,77 @@
+defmodule Plug.ServerSentEvent do
+  @moduledoc """
+  A module to generate messages according to the W3C Server-Sent Events
+  spec (http://www.w3.org/TR/eventsource/).
+  """
+  @type id    :: integer | String.t | nil
+  @type data  :: String.t | list(String.t) | []
+  @type event :: String.t | nil
+  @type retry :: integer | nil
+
+  defstruct id:    nil :: id,
+            data:  []  :: data,
+            event: nil :: event,
+            retry: nil :: retry
+
+  alias __MODULE__, as: SSE
+
+  @doc """
+  Transforms a ServerSentEvent to a String so it can be sent to the client.
+
+  It expects a Plug.ServerSentEvent struct as it's argument, returns a String
+  which can be passed as the body to the connection adapter.
+  """
+  @spec to_string(t) :: String.t
+  def to_string(%SSE{} = chunk) do
+    add_id_to_string([], chunk)
+    |> add_event_to_string(chunk)
+    |> add_retry_to_string(chunk)
+    |> add_data_to_string(chunk)
+    |> finalize
+  end
+
+  defp add_id_to_string(acc, %SSE{id: id}) do
+    add_field_to_string(acc, "id", id)
+  end
+
+  defp add_event_to_string(acc, %SSE{event: event}) do
+    add_field_to_string(acc, "event", event)
+  end
+
+  defp add_retry_to_string(acc, %SSE{retry: retry}) when is_integer(retry) or retry == nil do
+    add_field_to_string(acc, "retry", retry)
+  end
+
+  defp add_data_to_string(acc, %SSE{data: data}) when is_binary(data) do
+    add_field_to_string(acc, "data", data)
+  end
+  defp add_data_to_string(acc, %SSE{data: data}) do
+    Enum.map(data, &build_line("data", &1))
+    |> Enum.reverse
+    |> Enum.concat(acc)
+  end
+
+  defp add_field_to_string(acc, _, nil), do: acc
+  defp add_field_to_string(acc, field_name, field_value) do
+    [build_line(field_name, field_value)] ++ acc
+  end
+
+  defp build_line(field_name, field_value) do
+    if is_binary(field_value) do
+      value = String.replace(field_value, "\n", "")
+      line(field_name, value)
+    else
+      line(field_name, field_value)
+    end
+  end
+
+  defp line(field_name, field_value) do
+    "#{field_name}:#{field_value}\n"
+  end
+
+  defp finalize([]), do: "\n\n"
+  defp finalize(acc) do
+    Enum.reverse(acc, ["\n"])
+    |> Enum.join
+  end
+end

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -172,6 +172,12 @@ defmodule Plug.ConnTest do
     assert conn.resp_body == "HELLO\nWORLD\n"
   end
 
+  test "send_chunked/3 with ServerSentEvent" do
+    conn = conn(:get, "/foo") |> send_chunked(200)
+    {:ok, conn} = chunk(conn, %Plug.ServerSentEvent{data: ["WORLD"]})
+    assert conn.resp_body == "data:WORLD\n\n"
+  end
+
   test "send_chunked/3 sends self a message" do
     refute_received {:plug_conn, :sent}
     conn(:get, "/foo") |> send_chunked(200)

--- a/test/plug/server_sent_event_test.exs
+++ b/test/plug/server_sent_event_test.exs
@@ -1,0 +1,43 @@
+defmodule Plug.ServerSentEventTest do
+  use ExUnit.Case, async: true
+
+  alias Plug.ServerSentEvent, as: SSE
+
+  test "to_string with empty SSE" do
+    assert SSE.to_string(%SSE{}) == "\n\n"
+  end
+
+  test "to_string of SSE with just an ID" do
+    assert SSE.to_string(%SSE{id: 123}) == "id:123\n\n"
+  end
+
+  test "to_string of SSE with just data as a string" do
+    assert SSE.to_string(%SSE{data: "foobar"}) == "data:foobar\n\n"
+  end
+
+  test "to_string of SSE with just data as a list" do
+    assert SSE.to_string(%SSE{data: ["foobar"]}) == "data:foobar\n\n"
+  end
+
+  test "to_string of SSE with multiple lines of data" do
+    assert SSE.to_string(%SSE{data: ["foobar", "baz"]}) == "data:foobar\ndata:baz\n\n"
+  end
+
+  test "to_string of SSE data strips newlines" do
+    assert SSE.to_string(%SSE{data: ["foo\nbar", "baz\n\n"]}) == "data:foobar\ndata:baz\n\n"
+    assert SSE.to_string(%SSE{data: "foo\nbar"}) == "data:foobar\n\n"
+  end
+
+  test "to_string of SSE with just an event" do
+    assert SSE.to_string(%SSE{event: "post_created"}) == "event:post_created\n\n"
+  end
+
+  test "to_string of SSE with just a retry period" do
+    assert SSE.to_string(%SSE{retry: 5000}) == "retry:5000\n\n"
+  end
+
+  test "to_string of SSE with multiple fields" do
+    assert SSE.to_string(%SSE{id: 345, data: ["foo", "baz"], event: :created, retry: 5000})
+      == "id:345\nevent:created\nretry:5000\ndata:foo\ndata:baz\n\n"
+  end
+end


### PR DESCRIPTION
In order to send messages as a Server Sent Event they need a format
specified in the W3C's spec http://www.w3.org/TR/eventsource/.

Up to now it was left to each developer to format strings according
to this format. With this commit a developer can use a struct which
provides all available fields that a Server Sent Event message
may have.
