### PR TITLE
Adding requester's address information to Plug.Conn as 'peer'

### DIFF
--- a/lib/plug/adapters/cowboy/conn.ex
+++ b/lib/plug/adapters/cowboy/conn.ex
@@ -11,6 +11,7 @@ defmodule Plug.Adapters.Cowboy.Conn do
     {meth, req} = Request.method req
     {hdrs, req} = Request.headers req
     {qs, req}   = Request.qs req
+    {peer, req} = Request.peer req
 
     %Plug.Conn{
       adapter: {__MODULE__, req},
@@ -20,7 +21,8 @@ defmodule Plug.Adapters.Cowboy.Conn do
       port: port,
       query_string: qs,
       req_headers: hdrs,
-      scheme: scheme(transport)
+      scheme: scheme(transport),
+      peer: join_peer_address(peer)
    }
   end
 
@@ -71,6 +73,11 @@ defmodule Plug.Adapters.Cowboy.Conn do
   defp split_path(path) do
     segments = :binary.split(path, "/", [:global])
     for segment <- segments, segment != "", do: segment
+  end
+
+  defp join_peer_address({address_parts, port}) do
+    address = address_parts |> :inet.ntoa |> IO.iodata_to_binary
+    {address, port}
   end
 
   ## Multipart

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -21,6 +21,7 @@ defmodule Plug.Conn do
   * `req_headers` - the request headers as a list, example: `[{"content-type", "text/plain"}]`
   * `scheme` - the request scheme as an atom, example: `:http`
   * `query_string` - the request query string as a binary, example: `"foo=bar"`
+  * `peer` - the request's originator as a tuple of ip and source port, example: `{"93.184.216.119", 53196}`
 
   ## Fetchable fields
 
@@ -83,6 +84,7 @@ defmodule Plug.Conn do
   @type params       :: %{binary => param}
   @type query_string :: String.t
   @type resp_cookies :: %{binary => %{}}
+  @type peer         :: {String.t, 0..65335}
   @type t            :: %__MODULE__{
                          adapter:      adapter,
                          assigns:      assigns,
@@ -103,7 +105,8 @@ defmodule Plug.Conn do
                          scheme:       scheme,
                          script_name:  segments,
                          state:        state,
-                         status:       status}
+                         status:       status,
+                         peer:         peer}
 
   defstruct adapter:      {Plug.Conn, nil},
             assigns:      %{},
@@ -124,7 +127,8 @@ defmodule Plug.Conn do
             scheme:       :http,
             script_name:  [],
             state:        :unset,
-            status:       nil
+            status:       nil,
+            peer:         {"127.0.0.1", 0}
 
 
   defmodule NotSentError do

--- a/test/plug/adapters/cowboy/conn_test.exs
+++ b/test/plug/adapters/cowboy/conn_test.exs
@@ -71,6 +71,17 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
     assert {204, _, _} = request :get, "/headers", [{"foo", "bar"}, {"baz", "bat"}]
   end
 
+  def peer(conn) do
+    {address, port} = conn.peer
+    assert address == "127.0.0.1"
+    assert port <= 65335 && port >= 0
+    conn
+  end
+
+  test "makes peer address information available" do
+    request :get, "/peer", []
+  end
+
   def send_200(conn) do
     assert conn.state == :unset
     assert conn.resp_body == nil


### PR DESCRIPTION
I found myself needing to know the requester's ip address, rather than pulling it out with `:cowboy_req.peer` in my app, I added it to Plug. Think this'll be useful?
