### PR TITLE
Encapsulation of eaddrinuse error when starting cowboy

### DIFF
--- a/test/plug/adapters/cowboy/conn_test.exs
+++ b/test/plug/adapters/cowboy/conn_test.exs
@@ -1,3 +1,9 @@
+defmodule Plug.Adapters.Cowboy.ConnTest.Dummy do
+  def init(opts) do
+    opts
+  end
+end
+
 defmodule Plug.Adapters.Cowboy.ConnTest do
   use ExUnit.Case, async: true
 
@@ -36,6 +42,11 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
   end
 
   ## Tests
+
+  test "returns {:error, :eaddrinuse} when binding to a port already in use" do
+    {:error, code} = Plug.Adapters.Cowboy.http(Plug.Adapters.Cowboy.ConnTest.Dummy, [], port: 8001)
+    assert code == :eaddrinuse
+  end
 
   def root(%Conn{} = conn) do
     assert conn.method == "HEAD"

--- a/test/plug/adapters/cowboy_test.exs
+++ b/test/plug/adapters/cowboy_test.exs
@@ -1,11 +1,5 @@
-defmodule Plug.Adapters.CowboyTest.Dummy do
-  def init([]) do
-    [foo: :bar]
-  end
-end
-
 defmodule Plug.Adapters.CowboyTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   import Plug.Adapters.Cowboy
 
@@ -13,26 +7,7 @@ defmodule Plug.Adapters.CowboyTest do
     [foo: :bar]
   end
 
-  def start_server(ref) do
-    result = http(ref, [], [])
-    on_exit fn ->
-      :cowboy.stop_listener(ref.HTTP)
-    end
-    result
-  end
-
   @dispatch [{:_, [], [{:_, [], Plug.Adapters.Cowboy.Handler, {Plug.Adapters.CowboyTest, [foo: :bar]}}]}]
-
-  test "starting a connection successfully" do
-    { status, _ } = start_server(__MODULE__)
-    assert status == :ok
-  end
-
-  test "returns {:error, :eaddrinuse} when binding to a port already in use" do
-    start_server(Plug.Adapters.CowboyTest.Dummy)
-    {:error, code} = start_server(__MODULE__)
-    assert code == :eaddrinuse
-  end
 
   test "builds args for cowboy dispatch" do
     assert args(:http, __MODULE__, [], []) ==


### PR DESCRIPTION
Instead of the deeply nested error structure returned by cowboy, just return `{:error,:eaddrinuse}`.

This is to facilitate resolving https://github.com/phoenixframework/phoenix/issues/180, and was suggested there.
