### PR TITLE
Adding Plug.Test.recycle/1, resets a test connection.

### DIFF
--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -93,4 +93,19 @@ defmodule Plug.Test do
   def delete_req_cookie(_conn, key) when is_binary(key) do
     raise ArgumentError, message: "cannot put/delete request cookies after cookies were fetched"
   end
+
+
+  @doc """
+    Recycles the test connection so it can be used in subsequent requests.
+
+    Resets all fields to default values and copies previous response cookies
+    into the new connection's request cookies.
+  """
+  @spec recycle(Conn.t) :: Conn.t
+  def recycle(%Plug.Conn{resp_cookies: resp_cookies}) do
+    Enum.reduce resp_cookies, conn(:get, "/"), fn({key, %{value: value}}, acc) ->
+      put_req_cookie(acc, to_string(key), value)
+    end
+  end
+
 end

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -38,4 +38,49 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert {:ok, params, _} = adapter.parse_req_multipart(state, 1_000_000, fn _ -> end)
     assert params == %{"a" => "b", "c" => [%{"d" => "e"}, "f"]}
   end
+
+  test "recycle/1" do
+    conn = conn(:get, "/", a: "b", c: [%{d: "e"}, "f"], headers: [{"content-type", "text/plain"}])
+           |> put_req_cookie("req_cookie_a", "req_cookie_value_a")
+           |> put_req_cookie("req_cookie_b", "req_cookie_value_b")
+
+    response_cookies = %{"resp_cookie_a" => "resp_cookie_value_a",
+                         "resp_cookie_b" => "resp_cookie_value_b"}
+    conn = Enum.reduce response_cookies, conn, fn({key, value}, acc) ->
+             Plug.Conn.put_resp_cookie(acc, key, value)
+           end
+
+    new_conn = recycle(conn)
+
+    default = %Plug.Conn{}
+    assert new_conn.assigns == default.assigns
+    assert new_conn.before_send == default.before_send
+    assert new_conn.cookies == default.cookies # unfetched
+    assert new_conn.host == default.host
+    assert new_conn.method == default.method
+    assert new_conn.params == default.params # unfetched
+    assert new_conn.path_info == default.path_info
+    assert new_conn.private == default.private
+    assert new_conn.query_string == default.query_string
+    assert new_conn.req_cookies == default.req_cookies # unfetched
+    assert new_conn.resp_body == default.resp_body
+    assert new_conn.resp_cookies == default.resp_cookies
+    assert new_conn.resp_headers == default.resp_headers
+    assert new_conn.scheme == default.scheme
+    assert new_conn.script_name == default.script_name
+    assert new_conn.state == default.state
+    assert new_conn.status == default.status
+
+    assert new_conn.port == 80
+    assert new_conn.adapter == {Plug.Adapters.Test.Conn, %{chunks: nil, method: "GET", params: nil, req_body: ""}}
+
+    # test the actual contents of fetched fields
+    fetched_default  = default  |> Plug.Conn.fetch_params |> Plug.Conn.fetch_cookies
+    fetched_new_conn = new_conn |> Plug.Conn.fetch_params |> Plug.Conn.fetch_cookies
+    assert fetched_new_conn.params == fetched_default.params
+
+    # previous response cookies should be copied into the request cookies
+    assert fetched_new_conn.cookies == response_cookies
+    assert fetched_new_conn.req_cookies == response_cookies
+  end
 end


### PR DESCRIPTION
As per https://github.com/phoenixframework/phoenix/issues/172#issuecomment-49239003.

Previous response cookies are moved into the request cookies field for use in the next request.

Any suggestions appreciated! :)
