### PR TITLE
Addition of elixir logger and request_id

### DIFF
--- a/lib/plug/logger.ex
+++ b/lib/plug/logger.ex
@@ -1,0 +1,77 @@
+defmodule Plug.Logger do
+  @moduledoc """
+  A plug for logging basic request information. 
+  
+  It expects no options on initialization.
+
+  To configure just add Logger to your own application and we will utilize it's configuration.
+
+  To include logging of request id's include `:request_id` in your Logger `:metadata` field. 
+
+  If you plan on sending your own request ids they must follow the following format:
+  1. Be greater than 20 characters
+  2. Be less than 200 characters
+  3. Consist of ASCII letters, digits, or the characters +, /, =, and -
+
+  If we receive an invalid request id we will generate a new one.
+  """
+
+  require Logger
+  alias Plug.Conn
+  @behaviour Plug
+
+  def init(opts), do: opts
+
+  def call(conn, _config) do
+    request_id = get_request_id(conn)    
+    Logger.metadata(request_id: request_id)
+
+    path = path_to_iodata(conn.path_info)
+    Logger.info [conn.method, ?\s, path]
+
+    before_time = :os.timestamp()
+    Conn.register_before_send(conn, fn (conn) -> 
+      after_time = :os.timestamp()
+      diff = :timer.now_diff(after_time, before_time)
+
+      resp_time = formatted_diff(diff)
+      type = connection_type(conn)
+      Logger.info [type, ?\s, Integer.to_string(conn.status), ?\s, "in", ?\s, resp_time]
+
+      Conn.put_resp_header(conn, "x-request-id", request_id)
+    end)
+  end
+
+  defp generate_request_id, do: :crypto.rand_bytes(15) |> Base.encode64
+
+  defp formatted_diff(diff) do
+    if diff > 1000 do
+      [Integer.to_string(div(diff, 100)), "ms"]
+    else
+      [Integer.to_string(diff), "µs"]
+    end
+  end
+
+  defp connection_type(%{state: :chunked}), do: "Chunked"
+  defp connection_type(_), do: "Sent"
+
+  defp path_to_iodata(path), do: Enum.reduce(path, [], fn(i, acc) -> [acc, ?/, i] end)
+
+  defp valid_request_id?(s) do
+    Regex.match?(~r/[-A-Za-z0-9+\/=]+/, s) && byte_size(s) in 20..200
+  end
+
+  defp get_request_id(conn) do
+    request_id = case Conn.get_req_header(conn, "x-request-id") do
+      [] -> generate_request_id()
+      [val | _] -> val
+    end
+  
+    unless valid_request_id?(request_id) do
+      request_id = generate_request_id()
+    end
+
+    request_id
+  end
+end
+

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Plug.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [applications: [:crypto],
+    [applications: [:crypto, :logger],
      mod: {Plug, []}]
   end
 

--- a/test/plug/logger_test.exs
+++ b/test/plug/logger_test.exs
@@ -1,0 +1,94 @@
+defmodule Plug.LoggerTest do
+  use ExUnit.Case, async: false
+  use Plug.Test
+  import ExUnit.CaptureIO
+  require Logger
+
+  defmodule MyPlug do
+    use Plug.Builder
+
+    plug Plug.Logger
+    plug :passthrough
+
+    defp passthrough(conn, _) do
+      Plug.Conn.send_resp(conn, 200, "Passthrough")
+    end
+  end
+
+  defp call(conn) do
+    MyPlug.call(conn, [])
+  end
+
+  defmodule MyChunkedPlug do
+    use Plug.Builder
+
+    plug Plug.Logger
+    plug :passthrough
+
+    defp passthrough(conn, _) do
+      Plug.Conn.send_chunked(conn, 200)
+    end
+  end
+
+
+  defp capture_log(level \\ :debug, fun) do
+    Logger.configure(level: level)
+    capture_io(:user, fn ->
+      fun.()
+      Logger.flush()
+    end) |> clean_logs
+  after
+    Logger.configure(level: :debug)
+  end
+
+  defp clean_logs(logs) do
+    logs 
+      |> String.split("\n")
+      |> :lists.droplast
+  end
+
+  setup_all do
+    Logger.configure_backend(:console, colors: [enabled: false], metadata: [:request_id])
+    on_exit(fn ->
+      Logger.configure_backend(:console, [])
+    end)
+  end
+
+  test "logs proper message to console" do
+    [first_message, second_message] = capture_log(fn ->
+       conn(:get, "/hello/world") |> call
+    end)
+    assert Regex.match?(~r/request_id=[^-A-Za-z0-9+\/=]|=[^=]|={3,} [info]  GET hello\/world/u, first_message)
+    assert Regex.match?(~r/Sent 200 in [0-9]+[µm]s/u, second_message)
+  end
+
+  test "adds request id to headers" do 
+    conn = conn(:get, "/hello/work") |> call
+    refute Plug.Conn.get_resp_header(conn, "x-request-id") == nil
+  end
+
+  test "returns request id from request headers" do 
+    request_id = "01234567890123456789"
+    conn = conn(:get, "/hello/work")
+      |> put_req_header("x-request-id", request_id)
+      |> call
+
+    assert Plug.Conn.get_resp_header(conn, "x-request-id") == [request_id]
+  end
+
+  test "generates new request id for invalid request_id" do 
+    request_id = "01234567890"
+    conn = conn(:get, "/hello/work")
+      |> put_req_header("x-request-id", request_id)
+      |> call
+
+    refute Plug.Conn.get_resp_header(conn, "x-request-id") == [request_id]
+  end
+
+  test "logs chunked if chunked reply" do 
+    [_, second_message] = capture_log(fn ->
+       conn(:get, "/hello/world") |> MyChunkedPlug.call([])
+    end)
+    assert Regex.match?(~r/Chunked 200 in [0-9]+[µm]s/u, second_message)
+  end
+end


### PR DESCRIPTION
Adding basic logger support to plug. re https://github.com/phoenixframework/phoenix/issues/235

Also adding a unique request id to each request header, response and Logger metadata.

@josevalim I wanted to make sure you were okay with the addition of two plugs/API before I tested and documented. 
