### PR TITLE
Pull ex_doc and hackney deps from hex.pm instead of github

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,8 +20,9 @@ defmodule Plug.Mixfile do
 
   def deps do
     [{:cowboy, "~> 1.0.0", optional: true},
-     {:ex_doc, github: "elixir-lang/ex_doc", only: [:docs]},
-     {:hackney, github: "benoitc/hackney", only: [:test]}]
+     {:earmark, "~> 0.1", only: :docs},
+     {:ex_doc, "~> 0.5", only: :docs},
+     {:hackney, "~> 0.13", only: :test}]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{"cowboy": {:package, "1.0.0"},
   "cowlib": {:package, "1.0.0"},
-  "ex_doc": {:git, "git://github.com/elixir-lang/ex_doc.git", "ca71b84b9c3c7e23b4b661e485a909aee3fdbc3b", []},
-  "hackney": {:git, "git://github.com/benoitc/hackney.git", "476b4992c64873ed67bf6daa5c48f0a31c2435b8", []},
-  "mimetypes": {:git, "https://github.com/spawngrid/mimetypes.git", "47d37a977a7d633199822bf6b08353007483d00f", [ref: "master"]},
+  "earmark": {:package, "0.1.10"},
+  "ex_doc": {:package, "0.5.2"},
+  "hackney": {:package, "0.13.1"},
+  "idna": {:package, "1.0.1"},
   "ranch": {:package, "1.0.0"}}

--- a/test/plug/adapters/cowboy/conn_test.exs
+++ b/test/plug/adapters/cowboy/conn_test.exs
@@ -13,6 +13,7 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
   ## Cowboy setup for testing
 
   setup_all do
+    {:ok, _} = Application.ensure_all_started(:hackney)
     {:ok, _pid} = Plug.Adapters.Cowboy.http __MODULE__, [], port: 8001
 
     on_exit fn ->
@@ -205,7 +206,7 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
   test "https" do
     {:ok, _pid} = Plug.Adapters.Cowboy.https __MODULE__, [], @https_options
     assert {:ok, 200, _headers, client} = :hackney.get("https://127.0.0.1:8002/https", [], "", [])
-    assert {:ok, "OK", _client} = :hackney.body(client)
+    assert {:ok, "OK"} = :hackney.body(client)
     :hackney.close(client)
   after
     :ok = Plug.Adapters.Cowboy.shutdown __MODULE__.HTTPS
@@ -216,7 +217,7 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
   defp request(verb, path, headers \\ [], body \\ "") do
     {:ok, status, headers, client} =
       :hackney.request(verb, "http://127.0.0.1:8001" <> path, headers, body, [])
-    {:ok, body, _} = :hackney.body(client)
+    {:ok, body} = :hackney.body(client)
     :hackney.close(client)
     {status, headers, body}
   end


### PR DESCRIPTION
Make tests pass with the latest hackney (:hackney.body now returns a 2-elem tuple)
