### PR TITLE
Divide time diff properly in Logger plug

### DIFF
--- a/lib/plug/logger.ex
+++ b/lib/plug/logger.ex
@@ -64,7 +64,7 @@ defmodule Plug.Logger do
 
   defp formatted_diff(diff) do
     if diff > 1000 do
-      [Integer.to_string(div(diff, 100)), "ms"]
+      [Integer.to_string(div(diff, 1000)), "ms"]
     else
       [Integer.to_string(diff), "µs"]
     end


### PR DESCRIPTION
Spent few min trying to figure out why my API was reporting that it was slow =)
