### PR TITLE
Populate params field in Plug.Test.conn/4 when custom params are given.

### DIFF
--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -19,6 +19,7 @@ defmodule Plug.Adapters.Test.Conn do
       port: uri.port || 80,
       req_headers: headers,
       query_string: uri.query || "",
+      params: params || %Plug.Conn.Unfetched{aspect: :params},
       scheme: (uri.scheme || "http") |> String.downcase |> String.to_atom
    }
   end

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -14,6 +14,11 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert {:ok, "", _state} = adapter.read_req_body(state, length: 5)
   end
 
+  test "custom params" do
+    conn = conn(:get, "/", a: "b", c: [%{d: "e"}])
+    assert conn.params == %{"a" => "b", "c" => [%{"d" => "e"}]}
+  end
+
   test "no body or params" do
     conn = conn(:get, "/")
     {adapter, state} = conn.adapter

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -32,7 +32,7 @@ defmodule Plug.ParsersTest do
   end
 
   test "parses multipart bodies" do
-    conn = parse(conn(:post, "/?foo=bar", []))
+    conn = parse(conn(:post, "/?foo=bar"))
     assert conn.params == %{"foo" => "bar"}
 
     conn = parse(conn(:post, "/?foo=bar", [foo: "baz"]))


### PR DESCRIPTION
When constructing a test connection and specifying custom parameters, the connection's `params` field wouldn't populate, even after calling `fetch_params/1`. As far as I can tell, the only way to get it to populate was to test with a query string.

I don't believe the change I had to make to the `Plug.Parsers` test changes the test's semantics. I thought it better to change the call there rather than modify `fetch_params/1` to merge query string params into the already existing params (in order to artificially satisfy the test), please correct me if I'm wrong. :)
