### PR TITLE
Use 0.8.0 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can use plug in your projects in two steps:
     ```elixir
     def deps do
       [{:cowboy, "~> 1.0.0"},
-       {:plug, "~> 0.6.0"}]
+       {:plug, "~> 0.8.0"}]
     end
     ```
 


### PR DESCRIPTION
So that Elixir 1.0.0 users have the right version.
