### PR TITLE
Add docs badge to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ before_script:
   - mix local.hex --force
   - mix deps.get --only test
 script: mix test
+after_script:
+  - mix deps.get --only docs
+  - MIX_ENV=docs mix inch.report

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Plug
 
 [![Build Status](https://travis-ci.org/elixir-lang/plug.png?branch=master)](https://travis-ci.org/elixir-lang/plug)
+[![Inline docs](http://inch-ci.org/github/elixir-lang/plug.svg?branch=master)](http://inch-ci.org/github/elixir-lang/plug)
 
 Plug is:
 

--- a/mix.exs
+++ b/mix.exs
@@ -22,6 +22,7 @@ defmodule Plug.Mixfile do
     [{:cowboy, "~> 1.0", optional: true},
      {:earmark, "~> 0.1", only: :docs},
      {:ex_doc, "~> 0.6", only: :docs},
+     {:inch_ex, only: :docs},
      {:hackney, "~> 0.13", only: :test}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -4,4 +4,6 @@
   "ex_doc": {:package, "0.6.0"},
   "hackney": {:package, "0.13.1"},
   "idna": {:package, "1.0.1"},
+  "inch_ex": {:package, "0.2.1"},
+  "json": {:package, "0.3.2"},
   "ranch": {:package, "1.0.0"}}


### PR DESCRIPTION
Hi guys,

this patch would add a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-ci.org/github/elixir-lang/plug.svg?branch=master)](http://inch-ci.org/github/elixir-lang/plug)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Elixir programmers to document their public modules/functions and treat documentation as a first class citizen.

The Elixir support is still new, but [I already convinced Chris and José](https://github.com/phoenixframework/phoenix/pull/404) to give it a try and include it in the Phoenix Framework's README and we are having an active discussion about what can be changed to make this a useful tool for the Elixir community.

What do you think?
