### PR TITLE
Add support for custom session cookie serializers

### DIFF
--- a/lib/plug/session/store.ex
+++ b/lib/plug/session/store.ex
@@ -12,7 +12,7 @@ defmodule Plug.Session.Store do
   Initializes the store.
 
   The options returned from this function will be given
-  to `get/2`, `put/3` and `delete/2`.
+  to `get/3`, `put/4` and `delete/3`.
   """
   defcallback init(Plug.opts) :: Plug.opts
 


### PR DESCRIPTION
This is to ease integration with existing applications, in particular rails.

Current behaviour is maintained (serialize to ETF), but support for JSON is added.
