### PR TITLE
Allow customization of key generation in cookie session store

### DIFF
--- a/test/plug/session/cookie_test.exs
+++ b/test/plug/session/cookie_test.exs
@@ -48,6 +48,24 @@ defmodule Plug.Session.CookieTest do
     end
   end
 
+  test "defaults key generator opts" do
+    key_generator_opts = CookieStore.init(@default_opts).key_opts
+    assert key_generator_opts[:iterations] == 1000
+    assert key_generator_opts[:length] == 32
+    assert key_generator_opts[:digest] == :sha256
+  end
+
+  test "uses specified key generator opts" do
+    opts = @default_opts
+            |> Keyword.put(:key_iterations, 2000)
+            |> Keyword.put(:key_length, 64)
+            |> Keyword.put(:key_digest, :sha)
+    key_generator_opts = CookieStore.init(opts).key_opts
+    assert key_generator_opts[:iterations] == 2000
+    assert key_generator_opts[:length] == 64
+    assert key_generator_opts[:digest] == :sha
+  end
+
   ## Signed
 
   test "session cookies are signed" do


### PR DESCRIPTION
I figured it's better not to rely on the KeyGenerator defaults and have cookie store specific defaults for key generation.

Also, the test 'uses specified key generator opts' is not actually checking the results of `put` against the result the result of MessageEncryptor with keys generated with same params. Thought it would be doing a bit too much. This may be too little though. Let me know and I can put more effort into it.

This PR may create conflicts with the cookie serializers PR. I can resolve the conflicts and resubmit.

Thanks a lot.
