### PR TITLE
Fixes decoding for decryption errors

### DIFF
--- a/lib/plug/session/cookie.ex
+++ b/lib/plug/session/cookie.ex
@@ -121,7 +121,7 @@ defmodule Plug.Session.COOKIE do
       _ -> {nil, %{}}
     end
   end
-  defp decode(:error, _serializer, _serializer_config), do:
+  defp decode(:error, _serializer), do:
     {nil, %{}}
 
   defp derive(conn, key, key_opts) do


### PR DESCRIPTION
Missed this in the original PR for cookie serializers. Should I add a test or are the compilation warnings (which I missed) sufficient?
