### PR TITLE
Update docs on host matching in the `forward` macro

### DIFF
--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -226,7 +226,7 @@ defmodule Plug.Router do
   `match/3` and the others route macros accepts the following options:
 
     * `:host` - the host which the route should match. Defaults to `nil`,
-      meaning no host match, but can be a string like "example.com" or an
+      meaning no host match, but can be a string like "example.com" or a
       string ending with ".", like "subdomain." for a subdomain match
 
     * `:via` - matches the route against some specific HTTP methods
@@ -301,6 +301,8 @@ defmodule Plug.Router do
   `forward` accepts the following options:
 
   * `:to` - a Plug where the requests will be forwarded
+  * `:host` - a string representing the host or subdomain, exactly like in
+    `match/3`
 
   All remaining options are passed to the underlying plug.
   """


### PR DESCRIPTION
I updated the docs mentioning that a `:host` option can be passed also to the `Plug.Router.forward/2` macro, so that the docs are up to date with a9eba755c587202b668e82b02a5dbdcbfb05d39e.
