### PR TITLE
Plug conn coverage

### DIFF
--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -272,6 +272,13 @@ defmodule Plug.ConnTest do
     assert get_resp_header(conn, "x-body") == ["CHUNK"]
   end
 
+  test "chunk/2 raises if send_chunked/3 hasn't been called yet" do
+    conn = conn(:get, "/")
+    assert_raise ArgumentError, fn ->
+      conn |> chunk("foobar")
+    end
+  end
+
   test "put_resp_header/3" do
     conn1 = conn(:head, "/foo") |> put_resp_header("x-foo", "bar")
     assert get_resp_header(conn1, "x-foo") == ["bar"]


### PR DESCRIPTION
Code coverage tools suggested some untested sections of the `Plug.Conn` code. This commit introduces tests for some of those sections, mainly the ones related with raising a `Plug.Conn.AlreadySentException` with an already sent connection.
