### PR TITLE
Remove secure:true from Plug.Session ETS example in docs

### DIFF
--- a/lib/plug/session.ex
+++ b/lib/plug/session.ex
@@ -30,7 +30,7 @@ defmodule Plug.Session do
 
   ## Examples
 
-      plug Plug.Session, store: :ets, key: "_my_app_session", secure: true, table: :session
+      plug Plug.Session, store: :ets, key: "_my_app_session", table: :session
   """
 
   alias Plug.Conn


### PR DESCRIPTION
Most people have a localhost/hobby project setup when starting development. So copy-pasting that example turns into a not-working scenario.

Thanks to @devinus for debugging this and @josevalim for confirming.
