### PR TITLE
Fail in Plug.Conn.put_status/2 when the resp had already been sent

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -242,8 +242,12 @@ defmodule Plug.Conn do
   The list of allowed atoms is available in `Plug.Conn.Status`.
   """
   @spec put_status(t, status) :: t
-  def put_status(%Conn{} = conn, nil),    do: %{conn | status: nil}
-  def put_status(%Conn{} = conn, status), do: %{conn | status: Plug.Conn.Status.code(status)}
+  def put_status(%Conn{state: state} = conn, nil)
+      when state in @unsent, do: %{conn | status: nil}
+  def put_status(%Conn{state: state} = conn, status)
+      when state in @unsent, do: %{conn | status: Plug.Conn.Status.code(status)}
+  def put_status(%Conn{}, _status), do: raise AlreadySentError
+
 
   @doc """
   Sends a response to the client.

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -24,6 +24,18 @@ defmodule Plug.ConnTest do
     assert put_status(conn, :ok).status == 200
   end
 
+  test "put_status/2 raises when the connection had already been sent" do
+    conn = conn(:get, "/") |> send_resp(200, "foo")
+
+    assert_raise Plug.Conn.AlreadySentError, fn ->
+      conn |> put_status(200)
+    end
+
+    assert_raise Plug.Conn.AlreadySentError, fn ->
+      conn |> put_status(nil)
+    end
+  end
+
   test "put_private/3" do
     conn = conn(:get, "/")
     assert conn.private[:hello] == nil


### PR DESCRIPTION
Most of the `Plug.Conn` functions raise an `AlreadySentError` when the response has already been sent. This commit introduces the code and tests that make this function behave like the others.

I'm not 100% sure that `put_status/2` is similar to functions like, say, `put_resp_header/3` but I think so. One thing that doubted me is that `put_status/2` has no `put_resp_body/2` counterpart (you need to use `resp/3`). Is there a particular reason for that?

As always, thanks in advance!
