### PR TITLE
Add a Plug.Router.scope macro

### DIFF
--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -326,6 +326,46 @@ defmodule Plug.Router do
     end
   end
 
+  @scopable_methods [
+    :match,
+    :forward,
+    :get,
+    :post,
+    :put,
+    :patch,
+    :delete,
+    :options,
+  ]
+
+  @doc """
+  """
+  defmacro scope(prefix, opts \\ [], do_block)
+
+  # Multiple calls inside the block that gets passed to the `scope` macro
+  # (identified by `:__block__`).
+  defmacro scope(prefix, opts, do: {:__block__, metadata, methods}) do
+    allowed_filter = fn({name, _, _}) -> name in @scopable_methods end
+
+    unless Enum.all?(methods, allowed_filter) do
+      raise ArgumentError, message: "Only these methods are allowed in a" <>
+                                    "`scope` block: #{@scopable_methods}"
+    end
+
+    methods = Enum.map methods, fn(method) ->
+      Plug.Router.Utils.scope_method(method, prefix, opts)
+    end
+
+    {:__block__, metadata, methods}
+  end
+
+  # Single call inside the block passed to `scope`. In this case, the quoted
+  # expression that gets passed to `scope` is not a list of other calls but it's
+  # the quoted call itself.
+  defmacro scope(prefix, opts, do: method) do
+    Plug.Router.Utils.scope_method(method, prefix, opts)
+  end
+
+
   ## Match Helpers
 
   @doc false


### PR DESCRIPTION
This is a throwaway PR :smile:

I love the scoping functionality provided by the Phoenix framework (and by Rails and by Sinatra + gems) and would love to be able to use it with Plug's compiled routes. Don't get me wrong, I've got nothing against Phoenix, but I like using barebones Plug when I can just for speed and simplicity. I find it's somehow like the Rails vs. Sinatra use case.

Just for the sake of playing with Elixir (which is fun!), I jotted down an implementation of a `scope` macro (`Plug.Router.scope`) which turned out to work in most cases. I implemented the macro so that it delegates as much as possible to the already existing macros (`match`, `forward` and so on): it just "injects" the prefix path and forwards any additional option (like `:host`) to the original macro.

This way, scoped routes are just compiled and pattern matched like all other routes.

The implementation is far from perfect and I already spotted a couple of bugs (e.g. it doesn't play well with `match _ do...`), but I'm opening the PR anyway mostly to see if people like the idea and so that I have a place where I can push commits regarding this topic.

So, let me know :smile_cat: 
