### PR TITLE
Add support for custom methods in MethodOverride

### DIFF
--- a/lib/plug/method_override.ex
+++ b/lib/plug/method_override.ex
@@ -1,10 +1,7 @@
 defmodule Plug.MethodOverride do
   @moduledoc """
   This plug overrides the request's `POST` method with the method defined in
-  either:
-
-  * the `_method` parameter of the request or
-  * the `X-HTTP-Method-Override` request header.
+  the `_method` request parameter.
 
   The `POST` method can be overridden only with on of these HTTP methods:
 
@@ -38,18 +35,11 @@ defmodule Plug.MethodOverride do
 
   @spec override_method(Plug.Conn.t) :: Plug.Conn.t
   defp override_method(conn) do
-    method = conn |> fetch_method |> String.upcase
+    method = (conn.params["_method"] || "") |> String.upcase
 
     cond do
       method in @allowed_methods -> %{conn | method: method}
       true                       -> conn
     end
-  end
-
-  @spec fetch_method(Plug.Conn.t) :: String.t
-  defp fetch_method(conn) do
-    header = Plug.Conn.get_req_header(conn, "x-http-method-override")
-              |> List.first
-    conn.params["_method"] || header || ""
   end
 end

--- a/test/plug/method_override_test.exs
+++ b/test/plug/method_override_test.exs
@@ -4,21 +4,9 @@ defmodule Plug.MethodOverrideTest do
 
   @content_type_header {"content-type", "application/x-www-form-urlencoded"}
 
-  test "converts POST to DELETE when X-HTTP-Method-Override: DELETE header is specified" do
-    headers = [{"x-http-method-override", "DELETE"}, @content_type_header]
-    conn = call(conn(:post, "/", "", headers: headers))
-    assert conn.method == "DELETE"
-  end
-
   test "converts POST to DELETE when _method=DELETE param is specified" do
     conn = call(conn(:post, "/", "_method=DELETE", headers: [@content_type_header]))
     assert conn.method == "DELETE"
-  end
-
-  test "converts POST to PUT when X-HTTP-Method-Override: PUT header is specified" do
-    headers = [{"x-http-method-override", "PUT"}, @content_type_header]
-    conn = call(conn(:post, "/", "", headers: headers))
-    assert conn.method == "PUT"
   end
 
   test "converts POST to PUT when _method=PUT param is specified" do
@@ -26,21 +14,9 @@ defmodule Plug.MethodOverrideTest do
     assert conn.method == "PUT"
   end
 
-  test "converts POST to PATCH when X-HTTP-Method-Override: PATCH header is specified" do
-    headers = [{"x-http-method-override", "PATCH"}, @content_type_header]
-    conn = call(conn(:post, "/", "", headers: headers))
-    assert conn.method == "PATCH"
-  end
-
   test "converts POST to PATCH when _method=PATCH param is specified" do
     conn = call(conn(:post, "/", "_method=PATCH", headers: [@content_type_header]))
     assert conn.method == "PATCH"
-  end
-
-  test "the X-HTTP-Method-Override header works with non-uppercase methods" do
-    headers = [{"x-http-method-override", "pUt"}, @content_type_header]
-    conn = call(conn(:post, "/", "", headers: headers))
-    assert conn.method == "PUT"
   end
 
   test "the _method parameter works with non-uppercase methods" do


### PR DESCRIPTION
I am really fond of the "Custom HTTP methods" problem, that is, is it cool to use custom HTTP methods (like WebDAV does)?
I think it generally isn't that cool but it has its use cases. For more details about this issue, [this](http://programmers.stackexchange.com/questions/193821/are-there-any-problems-with-implementing-custom-http-methods) programmers.stackexchange.com question is a good read.

Anyways, the `MethodOverride` plug didn't provide any support for methods other than `PUT`, `PATCH` and `DELETE`.

In this PR, I mainly added that support using an optional option (`:override_any_method`) that can be passed to the `MethodOverride` plug. This option default to `false`, effectively leaving everything unchanged and not dropping support for anything.

Another (minor) "problem" was that `MethodOverride` cared about the **case** of the method: `PUT` would work while `put` would not. IMO, this is a fragile behaviour since sometimes `<form>` elements like to have a `method="post"` or `method="get"` attribute, so it makes sense to support lowercase (or any case at this point) here too.

I also added some more in-depth docs for the `MethodOverride` plug (including docs for the new options), refactored a bit and added tests for everything I changed/added.

Let me know what you think!
