### PR TITLE
Add a hex.pm version badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/elixir-lang/plug.svg?branch=master)](https://travis-ci.org/elixir-lang/plug)
 [![Inline docs](http://inch-ci.org/github/elixir-lang/plug.svg?branch=master)](http://inch-ci.org/github/elixir-lang/plug)
+[![Package](http://img.shields.io/hexpm/v/plug.svg)](https://hex.pm/packages/plug)
 
 Plug is:
 


### PR DESCRIPTION
The badge is provided by http://shields.io and shows the version of the package on [hex.pm](https://hex.pm). Maybe not super useful, but IMO it polishes the repository look on GitHub and at the same time it gives a quick view of what version to add in a `mix.exs` file.

**Edit** you can see the badge in action [on my fork](https://github.com/whatyouhide/plug/tree/hexpm-version-badge).
