### PR TITLE
Some refactoring and docs for Plug.Conn and Plug.Conn.Unfetched

### DIFF
--- a/lib/plug/conn/unfetched.ex
+++ b/lib/plug/conn/unfetched.ex
@@ -1,6 +1,13 @@
 defmodule Plug.Conn.Unfetched do
   @moduledoc """
   A struct used as default on unfetched fields.
+
+  The `:aspect` key of the struct specifies what field is still unfetched.
+
+  ## Examples
+
+      unfetched = %Plug.Conn.Unfetched{aspect: :cookies}
+
   """
 
   defstruct [:aspect]

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -535,9 +535,12 @@ defmodule Plug.ConnTest do
     assert get_session(conn, :key) == 42
   end
 
-  test "configure session" do
+  test "configure_session/2" do
     opts = Plug.Session.init(store: ProcessStore, key: "foobar")
     conn = conn(:get, "/") |> Plug.Session.call(opts) |> fetch_session()
+
+    conn = configure_session(conn, drop: false, renew: false)
+    assert conn.private[:plug_session_info] == nil
 
     conn = configure_session(conn, drop: true)
     assert conn.private[:plug_session_info] == :drop
@@ -547,6 +550,13 @@ defmodule Plug.ConnTest do
 
     conn = put_session(conn, :foo, :bar)
     assert conn.private[:plug_session_info] == :renew
+  end
+
+  test "configure_session/2 fails when there is no session" do
+    conn = conn(:get, "/")
+    assert_raise ArgumentError, fn ->
+      configure_session(conn, drop: true)
+    end
   end
 
   test "delete_session/2" do


### PR DESCRIPTION
`Plug.Conn.Unfetched`: just some added docs.

`Plug.Conn`:
- More detailed docs overall
- Refactored `full_path/1` in order to remove the use of a private function
- Major refactor to `configure_session/2`
- Replaces two calls to Erlang's `:lists` with Elixir's `List` module
- Added the `port_number` type (`0..65335`)

I added comments to the diff where I felt some choice had to be justified :). Let me know if something needs to be changed!
