### PR TITLE
Refine docs and add more tests for Plug.MIME

### DIFF
--- a/test/plug/mime_test.exs
+++ b/test/plug/mime_test.exs
@@ -5,18 +5,24 @@ defmodule Plug.MIMETest do
 
   doctest Plug.MIME
 
-  test :valid? do
+  test "valid?/1" do
     assert valid?("application/json")
     refute valid?("application/prs.vacation-photos")
   end
 
-  test :extensions do
+  test "extensions/1" do
     assert "json" in extensions("application/json")
     assert extensions("application/vnd.api+json") == []
   end
 
-  test :type do
+  test "type/1" do
     assert type("json") == "application/json"
     assert type("foo") == "application/octet-stream"
+  end
+
+  test "path/1" do
+    assert path("index.html") == "text/html"
+    assert path("inexistent.filetype") == "application/octet-stream"
+    assert path("without-extension") == "application/octet-stream"
   end
 end


### PR DESCRIPTION
- Refined docs adding `## Examples` headers to all docs (in order to be
  consistent with the rest of the Plug and Elixir docs) and fixing some typos
  here and there
- Added some doctests as well as tests for the `path/1` function
