### PR TITLE
Add meta utf-8 HTML tag in debugger.eex template

### DIFF
--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -134,6 +134,7 @@ defmodule Plug.Debugger do
     reason = Exception.normalize(kind, reason, stack)
     {status, title, message} = info(kind, reason)
 
+    conn = put_resp_content_type(conn, "text/html")
     send_resp conn, status, template(conn: conn, frames: frames(stack, opts),
                                      title: title, message: message,
                                      session: session, params: params)


### PR DESCRIPTION
Simple fix to enable utf8 encoding in the debugger page.

**From this**:
![image](https://cloud.githubusercontent.com/assets/464900/5534193/9ca68d96-8a28-11e4-84dd-11af420d34c4.png)

**To this**:
![image](https://cloud.githubusercontent.com/assets/464900/5534188/88bf8b98-8a28-11e4-9454-6bff1177b8e1.png)
