### PR TITLE
elixir-lang/plug -> elixir-plug/plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Plug
 
-[![Build Status](https://travis-ci.org/elixir-lang/plug.svg?branch=master)](https://travis-ci.org/elixir-lang/plug)
-[![Inline docs](http://inch-ci.org/github/elixir-lang/plug.svg?branch=master)](http://inch-ci.org/github/elixir-lang/plug)
+[![Build Status](https://travis-ci.org/elixir-plug/plug.svg?branch=master)](https://travis-ci.org/elixir-plug/plug)
+[![Inline docs](http://inch-ci.org/github/elixir-plug/plug.svg?branch=master)](http://inch-ci.org/github/elixir-plug/plug)
 
 Plug is:
 
@@ -251,8 +251,8 @@ Finally, remember all interactions in our official spaces follow our [Code of Co
 Plug source code is released under Apache 2 License.
 Check LICENSE file for more information.
 
-  [issues]: https://github.com/elixir-lang/plug/issues
-  [pulls]: https://github.com/elixir-lang/plug/pulls
+  [issues]: https://github.com/elixir-plug/plug/issues
+  [pulls]: https://github.com/elixir-plug/plug/pulls
   [ML]: https://groups.google.com/group/elixir-lang-core
   [code-of-conduct]: https://github.com/elixir-lang/elixir/blob/master/CODE_OF_CONDUCT.md
   [writing-docs]: http://elixir-lang.org/docs/stable/elixir/writing-documentation.html

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Plug.Mixfile do
      xref: [exclude: [:ranch, :cowboy, :cowboy_req, :cowboy_router]],
      docs: [extras: ["README.md"], main: "readme",
             source_ref: "v#{@version}",
-            source_url: "https://github.com/elixir-lang/plug"]]
+            source_url: "https://github.com/elixir-plug/plug"]]
   end
 
   # Configuration for the OTP application
@@ -36,6 +36,6 @@ defmodule Plug.Mixfile do
   defp package do
     %{licenses: ["Apache 2"],
       maintainers: ["José Valim"],
-      links: %{"GitHub" => "https://github.com/elixir-lang/plug"}}
+      links: %{"GitHub" => "https://github.com/elixir-plug/plug"}}
   end
 end


### PR DESCRIPTION
Fun IRC conversation that led to this:

```
[17:53:25]  <Radar>	gazler: elixir-plug org has existed since 14th July according to GitHub's API
[17:53:26]  <Radar>	https://api.github.com/orgs/elixir-plug
[17:53:42]  <Radar>	So I guess sometime between then + now. There is no easy way to see when a repo moved as far as I can tell.
[17:53:55]  <sevenseacat>	hax. nice.
[17:54:16]  <gazler>	Radar: Thanks Poirot, I didn't even consider checking the API
[17:54:47]  <Nicd->	Radar is Hercule?
[17:55:08]  <gazler>	He's certainly a detective
[17:55:21]  <Radar>	:) 
[17:56:26]  <Radar>	The repo was updated today but that could be as simple as a readme description or title change or someone being added to it... I don't know what circumstances updated_at on a repo on GitHub changes under.
[17:57:20]  <Nicd->	gazler: he just used his little grey cells
[17:57:45]  <Radar>	It does not help that https://github.com/elixir-plug/plug/blob/master/mix.exs#L18 hasn't been updated.
[17:57:54]  <Radar>	Nor https://github.com/elixir-plug/plug/blob/master/mix.exs#L39
[17:58:28]  <gazler>	Easy PR right there
[18:01:49]  <Radar>	Looking at https://api.github.com/repos/elixir-plug/plug/events?page=3 it looks like that there's a WatchEvent (#6257589367, at 2017-07-14T15:13:32Z) which is for elixir-lang/plug, but then the subsequent WatchEvent (#6258277227, at 2017-07-14T15:13:32Z, yes the same second) is for elixir-plug/plug. 
[18:02:12]  <Radar>	This would make me think that the repo was renamed around 15:13:32 UTC time on the 14th of July this year.
[18:02:37]  <Radar>	gazler: Is that precise enough for you? I do not think I can get more precise.
[18:04:39]  <Radar>	Once this train enters the Zone of Decent Internet I will submit a PR to change the links across the codebase to their new changes.
```