### PR TITLE
Fix :ets.foldl/3 usage on Plug.Upload.terminate/2, add test for it

### DIFF
--- a/lib/plug/upload.ex
+++ b/lib/plug/upload.ex
@@ -167,9 +167,9 @@ defmodule Plug.Upload do
   end
 
   def terminate(_reason, _state) do
-    :ets.foldl(@table, :ok, fn {_pid, _tmp, paths} ->
+    :ets.foldl(fn({_pid, _tmp, paths}, _) ->
       delete_paths(paths)
-    end)
+    end, :ok, @table)
     :ok
   end
 

--- a/test/plug/upload_test.exs
+++ b/test/plug/upload_test.exs
@@ -23,4 +23,10 @@ defmodule Plug.UploadTest do
         refute File.exists?(path)
     end
   end
+
+  test "terminate removes all files" do
+    {:ok, path} = Plug.Upload.random_file("sample")
+    :ok = Plug.Upload.terminate(:shutdown, [])
+    refute File.exists?(path)
+  end
 end


### PR DESCRIPTION
Hello,

Today I upgraded a Phoenix 1.2 app to Erlang/OTP 20 and Elixir 1.5.0... and was surprised to find that on init:restart() Plug.Uploader blew up at Plug.Upload.terminate/2 :open_mouth: 

I think I tracked it down to a bad ets:foldl/3, hopefully it's correct.

I added a test, not sure if it's ideal really. Anyways, hope this helps!