### PR TITLE
Raise nice error message when no route is defined in Plug.Router

### DIFF
--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -221,7 +221,10 @@ defmodule Plug.Router do
   end
 
   @doc false
-  defmacro __before_compile__(_env) do
+  defmacro __before_compile__(env) do
+    unless Module.defines?(env.module, {:do_match, 4}) do
+      raise "no routes defined in module #{inspect env.module} using Plug.Router"
+    end
     quote do
       import Plug.Router, only: []
     end


### PR DESCRIPTION
Right now the user is greeted with a nasty and confusing

    undefined function do_match/4

message. Make sure the message is nicer and easier to understand.