### PR TITLE
Improve Plug.Builder example to mirror real world use better

### DIFF
--- a/lib/plug/builder.ex
+++ b/lib/plug/builder.ex
@@ -72,8 +72,9 @@ defmodule Plug.Builder do
         plug Plug.Head
 
         def call(conn, opts) do
-          super(conn, opts) # calls Plug.Logger and Plug.Head
-          assign(conn, :called_all_plugs, true)
+          conn
+          |> super(opts) # calls Plug.Logger and Plug.Head
+          |> assign(:called_all_plugs, true)
         end
       end
 


### PR DESCRIPTION
```elixir
conn = super(conn, opts)
assign(conn, :called_all_plugs, true)
```
mirrors real world use better than
```elixir
super(conn, opts)
assign(conn, :called_all_plugs, true)
```