### PR TITLE
Add test for Plug.Logger log level option

### DIFF
--- a/test/plug/logger_test.exs
+++ b/test/plug/logger_test.exs
@@ -39,6 +39,17 @@ defmodule Plug.LoggerTest do
     defp halter(conn, _), do: halt(conn)
   end
 
+  defmodule MyDebugLevelPlug do
+    use Plug.Builder
+
+    plug Plug.Logger, log: :debug
+    plug :passthrough
+
+    defp passthrough(conn, _) do
+      Plug.Conn.send_resp(conn, 200, "Passthrough")
+    end
+  end
+
   test "logs proper message to console" do
     [first_message, second_message] = capture_log_lines fn ->
       call(conn(:get, "/"))
@@ -72,6 +83,14 @@ defmodule Plug.LoggerTest do
       MyHaltingPlug.call(conn(:get, "/foo"), [])
     end
     assert output =~ "Plug.LoggerTest.MyHaltingPlug halted in :halter/2"
+  end
+
+  test "logs proper log level to console" do
+    [first_message, second_message] = capture_log_lines fn ->
+      MyDebugLevelPlug.call(conn(:get, "/"), [])
+    end
+    assert first_message =~ ~r"\[debug\] GET /"u
+    assert second_message =~ ~r"Sent 200 in [0-9]+[µm]s"u
   end
 
   defp capture_log_lines(fun) do

--- a/test/plug/logger_test.exs
+++ b/test/plug/logger_test.exs
@@ -54,28 +54,28 @@ defmodule Plug.LoggerTest do
     [first_message, second_message] = capture_log_lines fn ->
       call(conn(:get, "/"))
     end
-    assert Regex.match?(~r/\[info\]  GET \//u, first_message)
-    assert Regex.match?(~r/Sent 200 in [0-9]+[µm]s/u, second_message)
+    assert first_message =~ ~r"\[info\]  GET /"u
+    assert second_message =~ ~r"Sent 200 in [0-9]+[µm]s"u
 
     [first_message, second_message] = capture_log_lines fn ->
       call(conn(:get, "/hello/world"))
     end
-    assert Regex.match?(~r/\[info\]  GET \/hello\/world/u, first_message)
-    assert Regex.match?(~r/Sent 200 in [0-9]+[µm]s/u, second_message)
+    assert first_message =~ ~r"\[info\]  GET /hello/world"u
+    assert second_message =~ ~r"Sent 200 in [0-9]+[µm]s"u
   end
 
   test "logs paths with double slashes and trailing slash" do
     [first_message, _] = capture_log_lines fn ->
       call(conn(:get, "/hello//world/"))
     end
-    assert Regex.match?(~r/\/hello\/\/world\//u, first_message)
+    assert first_message =~ ~r"/hello//world/"u
   end
 
   test "logs chunked if chunked reply" do
     [_, second_message] = capture_log_lines fn ->
       MyChunkedPlug.call(conn(:get, "/hello/world"), [])
     end
-    assert Regex.match?(~r/Chunked 200 in [0-9]+[µm]s/u, second_message)
+    assert second_message =~ ~r"Chunked 200 in [0-9]+[µm]s"u
   end
 
   test "logs halted connections if :log_on_halt is true" do


### PR DESCRIPTION
Plug is one of several libraries I look at most often as my reference for "how to do things" whenever I'm in doubt.  Thanks for that!

When tinkering with the configuration of Plug.Logger I noticed there wasn't a test for it and had a few spare minutes.