### PR TITLE
Add opts to Plug.Crypto.safe_binary_to_term

### DIFF
--- a/lib/plug/crypto.ex
+++ b/lib/plug/crypto.ex
@@ -9,8 +9,8 @@ defmodule Plug.Crypto do
   A restricted version a `:erlang.binary_to_term/1` that
   forbids possibly unsafe terms.
   """
-  def safe_binary_to_term(binary) when is_binary(binary) do
-    term = :erlang.binary_to_term(binary)
+  def safe_binary_to_term(binary, opts \\ []) when is_binary(binary) do
+    term = :erlang.binary_to_term(binary, opts)
     safe_terms(term)
     term
   end

--- a/test/plug/crypto_test.exs
+++ b/test/plug/crypto_test.exs
@@ -34,5 +34,9 @@ defmodule Plug.CryptoTest do
     assert_raise ArgumentError, fn ->
       safe_binary_to_term(:erlang.term_to_binary(%{1 => {:foo, [fn -> :bar end]}}))
     end
+
+    assert_raise ArgumentError, fn ->
+      safe_binary_to_term(<<131, 100, 0, 7, 103, 114, 105, 102, 102, 105, 110>>, [:safe])
+    end
   end
 end


### PR DESCRIPTION
This will allow the use of standard `binary_to_term` options like `[:safe]` in the uncommon cases that such functionality may be useful.