### PR TITLE
Add a no_default_onresponse option to Plug.Adapters.Cowboy.

### DIFF
--- a/lib/plug/adapters/cowboy.ex
+++ b/lib/plug/adapters/cowboy.ex
@@ -31,6 +31,9 @@ defmodule Plug.Adapters.Cowboy do
     * `:timeout` - Time in ms with no requests before Cowboy closes the connection.
       Defaults to 5000ms.
 
+    * `:no_default_onresponse` - Disable the default `onresponse/4` callback handler.
+      Defaults to false.
+
     * `:protocol_options` - Specifies remaining protocol options,
       see [Cowboy protocol docs](http://ninenines.eu/docs/en/cowboy/1.0/manual/cowboy_protocol/).
 
@@ -199,24 +202,29 @@ defmodule Plug.Adapters.Cowboy do
     {dispatch, opts} = Keyword.pop(opts, :dispatch)
     {acceptors, opts} = Keyword.pop(opts, :acceptors, 100)
     {protocol_options, opts} = Keyword.pop(opts, :protocol_options, [])
+    {no_default_onresponse, opts} = Keyword.pop(opts, :no_default_onresponse, false)
 
     dispatch = :cowboy_router.compile(dispatch)
     {extra_options, transport_options} = Keyword.split(opts, @protocol_options)
-    protocol_options = [env: [dispatch: dispatch]] ++ add_on_response(protocol_options) ++ extra_options
+    protocol_options = [env: [dispatch: dispatch]] ++ add_on_response(no_default_onresponse, protocol_options) ++ extra_options
 
     [ref, acceptors, non_keyword_opts ++ transport_options, protocol_options]
   end
 
-  defp add_on_response(protocol_options) do
-    case Keyword.pop(protocol_options, :onresponse) do
-      {nil, _} ->
-        [onresponse: &onresponse/4] ++ protocol_options
-      {onresponse, protocol_options} ->
-        [onresponse: fn status, headers, body, request ->
-          onresponse(status, headers, body, request)
-          onresponse.(status, headers, body, request)
-         end] ++ protocol_options
-    end
+  defp add_on_response(no_default_onresponse, protocol_options) do
+    {provided_onresponse, protocol_options} = Keyword.pop(protocol_options, :onresponse)
+
+    add_on_response(no_default_onresponse, provided_onresponse, protocol_options)
+  end
+
+  defp add_on_response(true, nil, protocol_options), do: protocol_options
+  defp add_on_response(true, fun, protocol_options), do: [onresponse: fun] ++ protocol_options
+  defp add_on_response(false, nil, protocol_options), do: [onresponse: &onresponse/4] ++ protocol_options
+  defp add_on_response(false, fun, protocol_options) do
+    [onresponse: fn status, headers, body, request ->
+        onresponse(status, headers, body, request)
+        fun.(status, headers, body, request)
+     end] ++ protocol_options
   end
 
   defp onresponse(status, _headers, _body, request) do

--- a/lib/plug/adapters/cowboy.ex
+++ b/lib/plug/adapters/cowboy.ex
@@ -31,8 +31,9 @@ defmodule Plug.Adapters.Cowboy do
     * `:timeout` - Time in ms with no requests before Cowboy closes the connection.
       Defaults to 5000ms.
 
-    * `:no_default_onresponse` - Disable the default `onresponse/4` callback handler.
-      Defaults to false.
+    * `:log_error_on_incomplete_requests` - An error is logged when the response status code is 400 and
+      no headers are set in the request.
+      Defaults to true.
 
     * `:protocol_options` - Specifies remaining protocol options,
       see [Cowboy protocol docs](http://ninenines.eu/docs/en/cowboy/1.0/manual/cowboy_protocol/).
@@ -202,25 +203,25 @@ defmodule Plug.Adapters.Cowboy do
     {dispatch, opts} = Keyword.pop(opts, :dispatch)
     {acceptors, opts} = Keyword.pop(opts, :acceptors, 100)
     {protocol_options, opts} = Keyword.pop(opts, :protocol_options, [])
-    {no_default_onresponse, opts} = Keyword.pop(opts, :no_default_onresponse, false)
+    {log_request_errors, opts} = Keyword.pop(opts, :log_error_on_incomplete_requests, true)
 
     dispatch = :cowboy_router.compile(dispatch)
     {extra_options, transport_options} = Keyword.split(opts, @protocol_options)
-    protocol_options = [env: [dispatch: dispatch]] ++ add_on_response(no_default_onresponse, protocol_options) ++ extra_options
+    protocol_options = [env: [dispatch: dispatch]] ++ add_on_response(log_request_errors, protocol_options) ++ extra_options
 
     [ref, acceptors, non_keyword_opts ++ transport_options, protocol_options]
   end
 
-  defp add_on_response(no_default_onresponse, protocol_options) do
+  defp add_on_response(log_request_errors, protocol_options) do
     {provided_onresponse, protocol_options} = Keyword.pop(protocol_options, :onresponse)
 
-    add_on_response(no_default_onresponse, provided_onresponse, protocol_options)
+    add_on_response(log_request_errors, provided_onresponse, protocol_options)
   end
 
-  defp add_on_response(true, nil, protocol_options), do: protocol_options
-  defp add_on_response(true, fun, protocol_options), do: [onresponse: fun] ++ protocol_options
-  defp add_on_response(false, nil, protocol_options), do: [onresponse: &onresponse/4] ++ protocol_options
-  defp add_on_response(false, fun, protocol_options) do
+  defp add_on_response(false, nil, protocol_options), do: protocol_options
+  defp add_on_response(false, fun, protocol_options), do: [onresponse: fun] ++ protocol_options
+  defp add_on_response(true, nil, protocol_options), do: [onresponse: &onresponse/4] ++ protocol_options
+  defp add_on_response(true, fun, protocol_options) do
     [onresponse: fn status, headers, body, request ->
         onresponse(status, headers, body, request)
         fun.(status, headers, body, request)

--- a/test/plug/adapters/cowboy_test.exs
+++ b/test/plug/adapters/cowboy_test.exs
@@ -88,21 +88,21 @@ defmodule Plug.Adapters.CowboyTest do
       assert is_function(on_response)
     end
 
-    test "elides the default onresponse handler if no_default_onresponse is set to true" do
+    test "elides the default onresponse handler if log_error_on_incomplete_requests is set to false" do
       assert [Plug.Adapters.CowboyTest.HTTP,
             _,
             _,
             [env: [dispatch: @dispatch]]] =
-           args(:http, __MODULE__, [], [no_default_onresponse: true])
+           args(:http, __MODULE__, [], [log_error_on_incomplete_requests: false])
     end
 
-    test "elides the default onresponse handler if no_default_onresponse is set to true and includes the user-provided onresponse handler" do
+    test "elides the default onresponse handler if log_error_on_incomplete_requests is set to false and includes the user-provided onresponse handler" do
       my_onresponse = fn (_, _, _, req) -> req end
       assert [Plug.Adapters.CowboyTest.HTTP,
             _,
             _,
             [env: [dispatch: @dispatch], onresponse: on_response]] =
-           args(:http, __MODULE__, [], [no_default_onresponse: true, protocol_options: [onresponse: my_onresponse]])
+           args(:http, __MODULE__, [], [log_error_on_incomplete_requests: false, protocol_options: [onresponse: my_onresponse]])
       assert is_function(on_response)
 
       assert on_response == my_onresponse

--- a/test/plug/adapters/cowboy_test.exs
+++ b/test/plug/adapters/cowboy_test.exs
@@ -78,6 +78,56 @@ defmodule Plug.Adapters.CowboyTest do
             [:ranch_listener_sup]} = child_spec(:http, __MODULE__, [], [])
   end
 
+  describe "onresponse handling" do
+    test "includes the default onresponse handler" do
+      assert [Plug.Adapters.CowboyTest.HTTP,
+            _,
+            _,
+            [env: [dispatch: @dispatch], onresponse: on_response]] =
+           args(:http, __MODULE__, [], [])
+      assert is_function(on_response)
+    end
+
+    test "elides the default onresponse handler if no_default_onresponse is set to true" do
+      assert [Plug.Adapters.CowboyTest.HTTP,
+            _,
+            _,
+            [env: [dispatch: @dispatch]]] =
+           args(:http, __MODULE__, [], [no_default_onresponse: true])
+    end
+
+    test "elides the default onresponse handler if no_default_onresponse is set to true and includes the user-provided onresponse handler" do
+      my_onresponse = fn (_, _, _, req) -> req end
+      assert [Plug.Adapters.CowboyTest.HTTP,
+            _,
+            _,
+            [env: [dispatch: @dispatch], onresponse: on_response]] =
+           args(:http, __MODULE__, [], [no_default_onresponse: true, protocol_options: [onresponse: my_onresponse]])
+      assert is_function(on_response)
+
+      assert on_response == my_onresponse
+    end
+
+    test "includes the default onresponse handler and the user-provided onresponse handler" do
+      # Grab a ref to the default onresponse handler
+      assert [Plug.Adapters.CowboyTest.HTTP,
+            _,
+            _,
+            [env: [dispatch: @dispatch], onresponse: default_response]] =
+           args(:http, __MODULE__, [], [])
+
+      my_onresponse = fn (_, _, _, req) -> req end
+      assert [Plug.Adapters.CowboyTest.HTTP,
+            _,
+            _,
+            [env: [dispatch: @dispatch], onresponse: on_response]] =
+           args(:http, __MODULE__, [], [protocol_options: [onresponse: my_onresponse]])
+      assert is_function(on_response)
+      assert on_response != default_response
+      assert on_response != my_onresponse
+    end
+  end
+
   defmodule MyPlug do
     def init(opts), do: opts
   end


### PR DESCRIPTION
This will provide an option to disable logging the Cowboy 400/no request headers error.

This is a potential solution for issues like #586.

I think disabling this error log makes sense because even if cowboy fixes the original issue addressed in #586 (returning `400` instead of `505`), any malformed request like `GET / HTTP/1.1\r\n\r\n` (no headers specified) will trigger this log message.