### PR TITLE
Fix Base64 mention on cookies

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -968,8 +968,9 @@ defmodule Plug.Conn do
 
   The cookie value is not automatically escaped. Therefore, if you
   want to store values with comma, quotes, etc, you need to explicitly
-  escape them or use a function such as `Base.encode64` when writing
-  and `Base.decode64` when reading the cookie.
+  escape them or use a function such as `Base.encode64(value, padding: false)`
+  when writing and `Base.decode64` when reading the cookie. Padding needs to
+  be disabled since `=` is not a valid character for cookie values.
 
   ## Options
 

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -969,8 +969,9 @@ defmodule Plug.Conn do
   The cookie value is not automatically escaped. Therefore, if you
   want to store values with comma, quotes, etc, you need to explicitly
   escape them or use a function such as `Base.encode64(value, padding: false)`
-  when writing and `Base.decode64` when reading the cookie. Padding needs to
-  be disabled since `=` is not a valid character for cookie values.
+  when writing and `Base.decode64(encoded, padding: false)` when reading
+  the cookie. Padding needs to be disabled since `=` is not a valid character
+  in cookie values.
 
   ## Options
 


### PR DESCRIPTION
Base64 characters are not valid for cookies so the previous phrase was incorrect. They need to be encoded.
See https://en.wikipedia.org/wiki/Base64#URL_applications for more info.

I was not sure if we should remove the mention about Base64 entirely.
wdyt?