### PR TITLE
Update Cowboy Adapater `onresponse` to handle module, func tuples 

### DIFF
--- a/lib/plug/adapters/cowboy.ex
+++ b/lib/plug/adapters/cowboy.ex
@@ -223,7 +223,7 @@ defmodule Plug.Adapters.Cowboy do
   defp add_on_response(false, {mod, fun}, protocol_options) when is_atom(mod) and is_atom(fun) do 
     [onresponse: fn status, headers, body, request -> 
         apply(mod, fun, [status, headers, body, request]) 
-     end ] ++ protocol_options
+     end] ++ protocol_options
   end
   defp add_on_response(true, nil, protocol_options), do: [onresponse: &onresponse/4] ++ protocol_options
   defp add_on_response(true, fun, protocol_options) when is_function(fun) do

--- a/lib/plug/adapters/cowboy.ex
+++ b/lib/plug/adapters/cowboy.ex
@@ -235,7 +235,7 @@ defmodule Plug.Adapters.Cowboy do
   defp add_on_response(true, {mod, fun}, protocol_options) when is_atom(mod) and is_atom(fun) do
     [onresponse: fn status, headers, body, request ->
         onresponse(status, headers, body, request)
-        apply(mod, func, [status, headers, body, request]) 
+        apply(mod, fun, [status, headers, body, request]) 
      end] ++ protocol_options
   end
 

--- a/lib/plug/adapters/cowboy.ex
+++ b/lib/plug/adapters/cowboy.ex
@@ -222,7 +222,7 @@ defmodule Plug.Adapters.Cowboy do
   defp add_on_response(false, fun, protocol_options) when is_function(fun), do: [onresponse: fun] ++ protocol_options
   defp add_on_response(false, {mod, fun}, protocol_options) when is_atom(mod) and is_atom(fun) do 
     [onresponse: fn status, headers, body, request -> 
-        apply(mod, func, [status, headers, body, request]) 
+        apply(mod, fun, [status, headers, body, request]) 
      end ] ++ protocol_options
   end
   defp add_on_response(true, nil, protocol_options), do: [onresponse: &onresponse/4] ++ protocol_options

--- a/lib/plug/adapters/cowboy.ex
+++ b/lib/plug/adapters/cowboy.ex
@@ -219,12 +219,23 @@ defmodule Plug.Adapters.Cowboy do
   end
 
   defp add_on_response(false, nil, protocol_options), do: protocol_options
-  defp add_on_response(false, fun, protocol_options), do: [onresponse: fun] ++ protocol_options
+  defp add_on_response(false, fun, protocol_options) when is_function(fun), do: [onresponse: fun] ++ protocol_options
+  defp add_on_response(false, {mod, fun}, protocol_options) when is_atom(mod) and is_atom(fun) do 
+    [onresponse: fn status, headers, body, request -> 
+        apply(mod, func, [status, headers, body, request]) 
+     end ] ++ protocol_options
+  end
   defp add_on_response(true, nil, protocol_options), do: [onresponse: &onresponse/4] ++ protocol_options
-  defp add_on_response(true, fun, protocol_options) do
+  defp add_on_response(true, fun, protocol_options) when is_function(fun) do
     [onresponse: fn status, headers, body, request ->
         onresponse(status, headers, body, request)
         fun.(status, headers, body, request)
+     end] ++ protocol_options
+  end
+  defp add_on_response(true, {mod, fun}, protocol_options) when is_atom(mod) and is_atom(fun) do
+    [onresponse: fn status, headers, body, request ->
+        onresponse(status, headers, body, request)
+        apply(mod, func, [status, headers, body, request]) 
      end] ++ protocol_options
   end
 

--- a/test/plug/adapters/cowboy_test.exs
+++ b/test/plug/adapters/cowboy_test.exs
@@ -81,30 +81,29 @@ defmodule Plug.Adapters.CowboyTest do
   describe "onresponse handling" do
     test "includes the default onresponse handler" do
       assert [Plug.Adapters.CowboyTest.HTTP,
-            _,
-            _,
-            [env: [dispatch: @dispatch], onresponse: on_response]] =
-           args(:http, __MODULE__, [], [])
+              _,
+              _,
+              [env: [dispatch: @dispatch], onresponse: on_response]] =
+             args(:http, __MODULE__, [], [])
       assert is_function(on_response)
     end
 
     test "elides the default onresponse handler if log_error_on_incomplete_requests is set to false" do
       assert [Plug.Adapters.CowboyTest.HTTP,
-            _,
-            _,
-            [env: [dispatch: @dispatch]]] =
-           args(:http, __MODULE__, [], [log_error_on_incomplete_requests: false])
+              _,
+              _,
+              [env: [dispatch: @dispatch]]] =
+             args(:http, __MODULE__, [], [log_error_on_incomplete_requests: false])
     end
 
     test "elides the default onresponse handler if log_error_on_incomplete_requests is set to false and includes the user-provided onresponse handler" do
       my_onresponse = fn (_, _, _, req) -> req end
       assert [Plug.Adapters.CowboyTest.HTTP,
-            _,
-            _,
-            [env: [dispatch: @dispatch], onresponse: on_response]] =
-           args(:http, __MODULE__, [], [log_error_on_incomplete_requests: false, protocol_options: [onresponse: my_onresponse]])
+              _,
+              _,
+              [env: [dispatch: @dispatch], onresponse: on_response]] =
+             args(:http, __MODULE__, [], [log_error_on_incomplete_requests: false, protocol_options: [onresponse: my_onresponse]])
       assert is_function(on_response)
-
       assert on_response == my_onresponse
     end
 
@@ -113,16 +112,16 @@ defmodule Plug.Adapters.CowboyTest do
     test "elides the default onresponse handler if log_error_on_incomplete_requests is set to false and handles user-provided onresponse tuple " do
       my_onresponse = {Plug.Adapters.CowboyTest, :my_onresponse_handler}
       assert [Plug.Adapters.CowboyTest.HTTP,
-            _,
-            _,
-            [env: [dispatch: @dispatch], onresponse: default_response]] =
-           args(:http, __MODULE__, [], [])
+              _,
+              _,
+              [env: [dispatch: @dispatch], onresponse: default_response]] =
+             args(:http, __MODULE__, [], [])
 
       assert [Plug.Adapters.CowboyTest.HTTP,
-            _,
-            _,
-            [env: [dispatch: @dispatch], onresponse: on_response]] =
-           args(:http, __MODULE__, [], [log_error_on_incomplete_requests: false, protocol_options: [onresponse: my_onresponse]])
+              _,
+              _,
+              [env: [dispatch: @dispatch], onresponse: on_response]] =
+             args(:http, __MODULE__, [], [log_error_on_incomplete_requests: false, protocol_options: [onresponse: my_onresponse]])
       assert is_function(on_response)
       assert on_response != default_response
     end
@@ -130,17 +129,17 @@ defmodule Plug.Adapters.CowboyTest do
     test "includes the default onresponse handler and the user-provided onresponse handler" do
       # Grab a ref to the default onresponse handler
       assert [Plug.Adapters.CowboyTest.HTTP,
-            _,
-            _,
-            [env: [dispatch: @dispatch], onresponse: default_response]] =
-           args(:http, __MODULE__, [], [])
+              _,
+              _,
+              [env: [dispatch: @dispatch], onresponse: default_response]] =
+             args(:http, __MODULE__, [], [])
 
       my_onresponse = fn (_, _, _, req) -> req end
       assert [Plug.Adapters.CowboyTest.HTTP,
-            _,
-            _,
-            [env: [dispatch: @dispatch], onresponse: on_response]] =
-           args(:http, __MODULE__, [], [protocol_options: [onresponse: my_onresponse]])
+              _,
+              _,
+              [env: [dispatch: @dispatch], onresponse: on_response]] =
+             args(:http, __MODULE__, [], [protocol_options: [onresponse: my_onresponse]])
       assert is_function(on_response)
       assert on_response != default_response
       assert on_response != my_onresponse
@@ -149,17 +148,17 @@ defmodule Plug.Adapters.CowboyTest do
     test "includes the default onresponse handler and handles the user-provided onresponse handler tuple" do
       # Grab a ref to the default onresponse handler
       assert [Plug.Adapters.CowboyTest.HTTP,
-            _,
-            _,
-            [env: [dispatch: @dispatch], onresponse: default_response]] =
-           args(:http, __MODULE__, [], [])
+              _,
+              _,
+              [env: [dispatch: @dispatch], onresponse: default_response]] =
+             args(:http, __MODULE__, [], [])
 
       my_onresponse = {Plug.Adapters.CowboyTest, :my_onresponse_handler}
       assert [Plug.Adapters.CowboyTest.HTTP,
-            _,
-            _,
-            [env: [dispatch: @dispatch], onresponse: on_response]] =
-           args(:http, __MODULE__, [], [protocol_options: [onresponse: my_onresponse]])
+              _,
+              _,
+              [env: [dispatch: @dispatch], onresponse: on_response]] =
+             args(:http, __MODULE__, [], [protocol_options: [onresponse: my_onresponse]])
       assert is_function(on_response)
       assert on_response != default_response
       assert on_response != my_onresponse

--- a/test/plug/adapters/cowboy_test.exs
+++ b/test/plug/adapters/cowboy_test.exs
@@ -108,6 +108,25 @@ defmodule Plug.Adapters.CowboyTest do
       assert on_response == my_onresponse
     end
 
+    defp my_onresponse_handler(_, _, _, req), do: res
+
+    test "elides the default onresponse handler if log_error_on_incomplete_requests is set to false and handles user-provided onresponse tuple " do
+      my_onresponse = {Plug.Adapters.CowboyTest, :my_onresponse_handler}
+      assert [Plug.Adapters.CowboyTest.HTTP,
+            _,
+            _,
+            [env: [dispatch: @dispatch], onresponse: default_response]] =
+           args(:http, __MODULE__, [], [])
+
+      assert [Plug.Adapters.CowboyTest.HTTP,
+            _,
+            _,
+            [env: [dispatch: @dispatch], onresponse: on_response]] =
+           args(:http, __MODULE__, [], [log_error_on_incomplete_requests: false, protocol_options: [onresponse: my_onresponse]])
+      assert is_function(on_response)
+      assert on_response != default_response
+    end
+
     test "includes the default onresponse handler and the user-provided onresponse handler" do
       # Grab a ref to the default onresponse handler
       assert [Plug.Adapters.CowboyTest.HTTP,
@@ -126,6 +145,26 @@ defmodule Plug.Adapters.CowboyTest do
       assert on_response != default_response
       assert on_response != my_onresponse
     end
+
+    test "includes the default onresponse handler and handles the user-provided onresponse handler tuple" do
+      # Grab a ref to the default onresponse handler
+      assert [Plug.Adapters.CowboyTest.HTTP,
+            _,
+            _,
+            [env: [dispatch: @dispatch], onresponse: default_response]] =
+           args(:http, __MODULE__, [], [])
+
+      my_onresponse = {Plug.Adapters.CowboyTest, :my_onresponse_handler}
+      assert [Plug.Adapters.CowboyTest.HTTP,
+            _,
+            _,
+            [env: [dispatch: @dispatch], onresponse: on_response]] =
+           args(:http, __MODULE__, [], [protocol_options: [onresponse: my_onresponse]])
+      assert is_function(on_response)
+      assert on_response != default_response
+      assert on_response != my_onresponse
+    end
+
   end
 
   defmodule MyPlug do


### PR DESCRIPTION
Recently I needed to modify the cowboy default response. Unfortunately the default way of passing in a function via `http.protocol_options.onresponse` does not play well with release libraries. 

The simplest approach that doesn't rely on modifying compile time behaviors of release libraries seemed to be passing a module/function tuple, like this: 

`http: [protocol_options: [onresponse: {MyWebApp.Endpoint, :on_response}]],`

It worked well in my application, so I though I'd share. For similar issues and resolutions:
    
    - https://github.com/bitwalker/distillery/issues/185
    - https://github.com/trenpixster/addict/issues/70
    - https://github.com/ueberauth/guardian/issues/187

Please let me know if there would be anything else I need to do for a PR. I read the contributing section of the readme, but I always seem to some detail. :-) 

