### PR TITLE
Minor bug: When validate_header_keys_during_test is not set it raises for wrong reason

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1203,7 +1203,7 @@ defmodule Plug.Conn do
   end
 
   defp validate_header_key_if_test!({Plug.Adapters.Test.Conn, _}, key) do
-    if Application.get_env(:plug, :validate_header_keys_during_test) && not valid_header_key?(key) do
+    if Application.fetch_env!(:plug, :validate_header_keys_during_test) and not valid_header_key?(key) do
       raise InvalidHeaderError, "header key is not lowercase: " <> inspect(key)
     end
   end

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1203,7 +1203,7 @@ defmodule Plug.Conn do
   end
 
   defp validate_header_key_if_test!({Plug.Adapters.Test.Conn, _}, key) do
-    if Application.get_env(:plug, :validate_header_keys_during_test) and not valid_header_key?(key) do
+    if Application.get_env(:plug, :validate_header_keys_during_test) && not valid_header_key?(key) do
       raise InvalidHeaderError, "header key is not lowercase: " <> inspect(key)
     end
   end


### PR DESCRIPTION
You cannot do boolean operations on `nil`s so this raises for the wrong reason.

    iex> Application.get_env(:plug, :validate_header_keys_during_test) and not valid_header_key?(key)
    ** (BadBooleanError) expected a boolean on left-side of "and", got: nil

So I decided to use `&&` instead of `and`. I'm not quite sure how to test it safely cause of `Application.get_env` usage, but I'm dropping it here cause I noticed this minor bug.