### PR TITLE
Fix start function for Cowboy 2 adapter

### DIFF
--- a/test/plug/adapters/cowboy2_test.exs
+++ b/test/plug/adapters/cowboy2_test.exs
@@ -21,7 +21,7 @@ defmodule Plug.Adapters.Cowboy2Test do
                modules: [:ranch_listener_sup],
                restart: :permanent,
                shutdown: :infinity,
-               start: {:cowboy, :start_clear, _},
+               start: {:ranch_listener_sup, :start_link, _},
                type: :supervisor
              } = Supervisor.child_spec(spec, [])
     end
@@ -113,7 +113,7 @@ defmodule Plug.Adapters.Cowboy2Test do
     assert %{
              id: {:ranch_listener_sup, Plug.Adapters.Cowboy2Test.HTTP},
              modules: [:ranch_listener_sup],
-             start: {:cowboy, :start_clear, _},
+             start: {:ranch_listener_sup, :start_link, _},
              restart: :permanent,
              shutdown: :infinity,
              type: :supervisor


### PR DESCRIPTION
Previously, the cowboy start_clear/start_tls functions were being used directly.
This meant that they were being started under the supervision tree for ranch and
not the supervision tree for the actual application. This approach use
`ranch_listener_sup` as the entry point instead. This matches what happens in
the Cowboy adapter.