### PR TITLE
Test on OTP 20.1 due to the zlib issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 sudo: false
-elixir: 1.4.1
-otp_release: 19.1
+elixir: 1.5.2
+otp_release: 20.1
 env:
   - COWBOY_VERSION=1.0
   - COWBOY_VERSION=2.0


### PR DESCRIPTION
Due to the recent zlib issues I was thinking it makes sense to test against those versions, especially to make sure the released Cowboy 1 support is unaffected.

I've bumped Elixir as well because I don't remember if 1.4 supported OTP 20.