### PR TITLE
Support HTTP/2 server push

### DIFF
--- a/lib/plug/adapters/cowboy/conn.ex
+++ b/lib/plug/adapters/cowboy/conn.ex
@@ -62,6 +62,10 @@ defmodule Plug.Adapters.Cowboy.Conn do
     :cowboy_req.body(req, opts)
   end
 
+  def push(_req, _path, _headers) do
+    {:error, :not_supported}
+  end
+
   ## Helpers
 
   defp scheme(:tcp), do: :http

--- a/lib/plug/adapters/cowboy2/conn.ex
+++ b/lib/plug/adapters/cowboy2/conn.ex
@@ -75,6 +75,18 @@ defmodule Plug.Adapters.Cowboy2.Conn do
     {:ok, "", req}
   end
 
+  def push(req, path, headers) do
+    opts =
+      case {req.port, req.sock} do
+        {:undefined, {_, port}} when port in [80, 443] -> %{}
+        {:undefined, {_, port}} -> %{port: port}
+        {port, _} when port in [80, 443] -> %{}
+        {port, _} -> %{port: port}
+      end
+
+    :cowboy_req.push(path, to_headers_map(headers), req, opts)
+  end
+
   ## Helpers
 
   defp to_headers_list(headers) when is_list(headers) do

--- a/lib/plug/adapters/cowboy2/conn.ex
+++ b/lib/plug/adapters/cowboy2/conn.ex
@@ -85,6 +85,7 @@ defmodule Plug.Adapters.Cowboy2.Conn do
       end
 
     :cowboy_req.push(path, to_headers_map(headers), req, opts)
+    {:ok, req}
   end
 
   ## Helpers

--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -14,7 +14,7 @@ defmodule Plug.Adapters.Test.Conn do
 
     {body, body_params, params, req_headers} = body_or_params(body_or_params, query, conn.req_headers)
     state = %{method: method, params: params, req_body: body,
-              chunks: nil, ref: make_ref(), owner: owner}
+              pushes: [], chunks: nil, ref: make_ref(), owner: owner}
 
     %Plug.Conn{conn |
       adapter: {__MODULE__, state},
@@ -87,9 +87,8 @@ defmodule Plug.Adapters.Test.Conn do
     {tag, data, %{state | req_body: rest}}
   end
 
-  def push(%{owner: owner, ref: ref} = state, path, headers) do
-    send owner, {ref, {:push, path, headers}}
-    {:ok, state}
+  def push(%{pushes: pushes} = state, path, headers) do
+    {:ok, %{state | pushes: [{path, headers} | pushes]}}
   end
 
   ## Private helpers

--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -87,6 +87,11 @@ defmodule Plug.Adapters.Test.Conn do
     {tag, data, %{state | req_body: rest}}
   end
 
+  def push(%{owner: owner, ref: ref}, path, headers) do
+    send owner, {ref, {:push, path, headers}}
+    :ok
+  end
+
   ## Private helpers
 
   defp body_or_params(nil, _query, headers),

--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -87,9 +87,9 @@ defmodule Plug.Adapters.Test.Conn do
     {tag, data, %{state | req_body: rest}}
   end
 
-  def push(%{owner: owner, ref: ref}, path, headers) do
+  def push(%{owner: owner, ref: ref} = state, path, headers) do
     send owner, {ref, {:push, path, headers}}
-    :ok
+    {:ok, state}
   end
 
   ## Private helpers

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -934,6 +934,50 @@ defmodule Plug.Conn do
   end
 
   @doc """
+  Push a resource to the client. Server pushes must happen prior to a response
+  being sent. If a server push is attempted after a response is sent then a
+  `Plug.Conn.AlreadySentError` will be raised.
+
+  If the adapter does not support server push then this is a noop.
+  """
+  @spec push(t, String.t, Keyword.t) :: t
+  def push(conn, path, headers \\ []) do
+    adapter_push(conn, path, headers)
+    conn
+  end
+
+  @doc """
+  This function is the same as `push/3` except it will raise If the adapter
+  does not support server push.
+  """
+  @spec push!(t, String.t, Keyword.t) :: t
+  def push!(%Conn{adapter: {adapter, _}} = conn, path, headers \\ []) do
+    case adapter_push(conn, path, headers) do
+      :ok ->
+        conn
+
+      _ ->
+        raise "server push not supported by #{inspect(adapter)}." <>
+        "You should either delete the call to `push!/3` or switch to an " <>
+        "adapter that does support server push such as Plug.Adapters.Cowboy2."
+    end
+  end
+
+  defp adapter_push(%Conn{state: state}, _path, _headers)
+  when not state in @unsent do
+    raise AlreadySentError
+  end
+
+  defp adapter_push(%Conn{adapter: {adapter, payload}}, path, headers) do
+    headers =
+      case List.keyfind(headers, "accept", 0) do
+        nil -> [{"accept", MIME.from_path(path)} | headers]
+        _ -> headers
+      end
+    adapter.push(payload, path, headers)
+  end
+
+  @doc """
   Fetches cookies from the request headers.
   """
   @spec fetch_cookies(t, Keyword.t) :: t

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -941,9 +941,11 @@ defmodule Plug.Conn do
   If the adapter does not support server push then this is a noop.
   """
   @spec push(t, String.t, Keyword.t) :: t
-  def push(conn, path, headers \\ []) do
-    adapter_push(conn, path, headers)
-    conn
+  def push(%Conn{adapter: {adapter, _}} = conn, path, headers \\ []) do
+    case adapter_push(conn, path, headers) do
+      {:ok, payload} -> %{conn | adapter: {adapter, payload}}
+      _ -> conn
+    end
   end
 
   @doc """
@@ -953,8 +955,8 @@ defmodule Plug.Conn do
   @spec push!(t, String.t, Keyword.t) :: t
   def push!(%Conn{adapter: {adapter, _}} = conn, path, headers \\ []) do
     case adapter_push(conn, path, headers) do
-      :ok ->
-        conn
+      {:ok, payload} ->
+        %{conn | adapter: {adapter, payload}}
 
       _ ->
         raise "server push not supported by #{inspect(adapter)}." <>

--- a/lib/plug/conn/adapter.ex
+++ b/lib/plug/conn/adapter.ex
@@ -80,5 +80,5 @@ defmodule Plug.Conn.Adapter do
   should be returned.
   """
   @callback push(payload, path :: String.t, headers :: Keyword.t) ::
-              :ok | {:error, term}
+              {:ok, payload} | {:error, term}
 end

--- a/lib/plug/conn/adapter.ex
+++ b/lib/plug/conn/adapter.ex
@@ -72,4 +72,13 @@ defmodule Plug.Conn.Adapter do
               {:ok, data :: binary, payload} |
               {:more, data :: binary, payload} |
               {:error, term}
+
+  @doc """
+  Push a resource to the client.
+
+  If the adapter does not support server push then `{:error, :not_supported}`
+  should be returned.
+  """
+  @callback push(payload, path :: String.t, headers :: Keyword.t) ::
+              :ok | {:error, term}
 end

--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -92,6 +92,13 @@ defmodule Plug.Test do
   end
 
   @doc """
+  Return the assets that have been pushed.
+  """
+  def sent_pushes(%Conn{adapter: {Plug.Adapters.Test.Conn, %{pushes: pushes}}}) do
+    Enum.reverse(pushes)
+  end
+
+  @doc """
   Puts a request cookie.
   """
   @spec put_req_cookie(Conn.t, binary, binary) :: Conn.t

--- a/test/plug/adapters/cowboy/conn_test.exs
+++ b/test/plug/adapters/cowboy/conn_test.exs
@@ -203,6 +203,27 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
            {"transfer-encoding", "chunked"}
   end
 
+  def push(conn) do
+    conn
+    |> push("/static/assets.css")
+    |> send_resp(200, "push")
+  end
+
+  test "push will not raise even though the adapter doesn't implement it" do
+    assert {200, _headers, "push"} = request :get, "/push"
+  end
+
+  def push_or_raise(conn) do
+    conn
+    |> push!("/static/assets.css")
+    |> send_resp(200, "push or raise")
+  end
+
+  test "push will raise because it is not implemented" do
+    assert {500, _headers, exception} = request :get, "/push_or_raise"
+    assert exception =~ "server push not supported"
+  end
+
   def read_req_body(conn) do
     expected = :binary.copy("abcdefghij", 100_000)
     assert {:ok, ^expected, conn} = read_body(conn)

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -68,6 +68,18 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert child_conn.host == "www.elixir-lang.org"
   end
 
+  test "push adds to the pushes list" do
+    conn =
+      conn(:get, "/")
+      |> Plug.Conn.push("/static/application.css", [{"accept", "text/css"}])
+      |> Plug.Conn.push("/static/application.js", [{"accept", "application/javascript"}])
+
+    pushes = Plug.Test.sent_pushes(conn)
+
+    assert {"/static/application.css", [{"accept", "text/css"}]} in pushes
+    assert {"/static/application.js", [{"accept", "application/javascript"}]} in pushes
+  end
+
   test "full URL overrides existing conn.host" do
     conn_with_host = conn(:get, "http://www.elixir-lang.org/")
     assert conn_with_host.host == "www.elixir-lang.org"

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -378,13 +378,13 @@ defmodule Plug.ConnTest do
   end
 
   test "push/3 performs a server push" do
-    conn(:get, "/foo") |> push("/static/application.css", [{"accept", "text/plain"}])
-    assert_receive({_, {:push, "/static/application.css", [{"accept", "text/plain"}]}})
+    conn = conn(:get, "/foo") |> push("/static/application.css", [{"accept", "text/plain"}])
+    assert {"/static/application.css", [{"accept", "text/plain"}]} in sent_pushes(conn)
   end
 
   test "push/3 works out the MIME type if not set" do
-    conn(:get, "/foo") |> push("/static/application.css")
-    assert_receive({_, {:push, "/static/application.css", [{"accept", "text/css"}]}})
+    conn = conn(:get, "/foo") |> push("/static/application.css")
+    assert {"/static/application.css", [{"accept", "text/css"}]} in sent_pushes(conn)
   end
 
   test "push/3 will raise if the response is sent before pushing" do


### PR DESCRIPTION
Two new functions have been added to Plug.Conn, `push/3` and `push!/3`. These
functions will perform a HTTP/2 server push if supported by the underlying
adapter. `push!/3` will raise if the adapter does not support server push.

The push must be sent before any response has been started.

Adapters must implement a new `push/3` callback. This should return `{:error,
:not_supported}` for adapters that do not support this feature. The test adapter
will send a message to the owner, allowing tests to check if a push promise is
set.

The port is determined in the request for the Cowboy 2 adapter to ensure that
the following line does not raise for a request that is not on port 80 or port
443.

https://github.com/ninenines/cowboy/blob/6cc162583df2e476db6464a58c96318e3063bd19/src/cowboy_http2.erl#L559
