### PR TITLE
Add router path to Plug.Conn

### DIFF
--- a/test/plug/router_test.exs
+++ b/test/plug/router_test.exs
@@ -363,6 +363,11 @@ defmodule Plug.RouterTest do
     end
   end
 
+  test "match_path/1" do
+    conn = call(Sample, conn(:get, "/params/get/a_value"))
+    assert Plug.Router.match_path(conn) == "/params/get/:param"
+  end
+
   test "assigns path params to conn params and path_params" do
     conn = call(Sample, conn(:get, "/params/get/a_value"))
     assert conn.params["param"] == "a_value"


### PR DESCRIPTION
In certain situations, it's very valuable to be able to access the matched router path of a request. Some examples include:

* Rate limiting—you want to rate limit on a route `/hello/:name`, not a variation of the route `/hello/robert`
* Metrics—you want to track metrics for an endpoint, but not necessarily each individual variation of the endpoint

I think that access to the matched router string is critically important information in these examples, and most likely others. I've added a function `Plug.Router.match_path` which returns the string path that the request was matched to.