### PR TITLE
strip trailing & in query_string before decoding it

### DIFF
--- a/lib/plug/conn/query.ex
+++ b/lib/plug/conn/query.ex
@@ -63,7 +63,10 @@ defmodule Plug.Conn.Query do
   end
 
   def decode(query, initial) do
-    parts = :binary.split(query, "&", [:global])
+    parts = query
+    |> String.trim_trailing("&")
+    |> :binary.split("&", [:global])
+
     Enum.reduce(Enum.reverse(parts), initial, &decode_string_pair(&1, &2))
   end
 

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -21,6 +21,11 @@ defmodule Plug.ParsersTest do
     assert conn.query_params["foo"] == "bar"
   end
 
+  test "don't add an empty query param if there is a trailing &" do
+    conn = parse(conn(:post, "/?foo=bar&"))
+    assert Map.has_key?(conn.query_params, "") == false
+  end
+
   test "keeps existing params" do
     conn = %{conn(:post, "/?query=foo", "body=bar") | params: %{"params" => "baz"}}
     conn = conn


### PR DESCRIPTION
It was not expected to me that a trailing `&` would result in a empty string key in `conn.query_params`.

