### PR TITLE
append match path

### DIFF
--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -413,6 +413,18 @@ defmodule Plug.Router do
     {quote(do: conn), method, match, params_match, host_match, guards, private, assigns}
   end
 
+  @doc false
+  def __put_route__(conn, path, fun) do
+    Plug.Conn.put_private(conn, :plug_route, {append_match_path(conn, path), fun})
+  end
+
+  defp append_match_path(%Plug.Conn{private: %{plug_route: {base_path, _}}}, path) do
+    base_path <> path
+  end
+  defp append_match_path(%Plug.Conn{}, path) do
+    path
+  end
+
   # Entry point for both forward and match that is actually
   # responsible to compile the route.
   defp compile(method, expr, options, contents) do
@@ -462,7 +474,7 @@ defmodule Plug.Router do
         conn = update_in unquote(conn).params, merge_params
         conn = update_in conn.path_params, merge_params
 
-        Plug.Conn.put_private(conn, :plug_route, {unquote(path), fn var!(conn) -> unquote(body) end})
+        Plug.Router.__put_route__(conn, unquote(path), fn var!(conn) -> unquote(body) end)
       end
     end
   end

--- a/test/plug/router_test.exs
+++ b/test/plug/router_test.exs
@@ -368,6 +368,11 @@ defmodule Plug.RouterTest do
     assert Plug.Router.match_path(conn) == "/params/get/:param"
   end
 
+  test "match_path/1 on forward to router" do
+    conn = call(Sample, conn(:get, "/step1/step2/fancy_id/abc123"))
+    assert Plug.Router.match_path(conn) == "/step1/*glob/step2/*glob/fancy_id/:id"
+  end
+
   test "assigns path params to conn params and path_params" do
     conn = call(Sample, conn(:get, "/params/get/a_value"))
     assert conn.params["param"] == "a_value"


### PR DESCRIPTION
I chose to strip the glob-segment of all segments except for the last one. 

forward auto append "/*glob", so otherwise the `match_path/1 on forward to route` test case would result in `/step1/*glob/step2/*glob/fancy_id/:id`. 

Fixes #634