### PR TITLE
Add a .formatter.exs file that exports formatter configuration

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,14 @@
+# Used by "mix format" and to export configuration.
+export_locals_without_parens = [
+  plug: 1,
+  plug: 2,
+  forward: 2,
+  forward: 3,
+  forward: 4
+]
+
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: export_locals_without_parens,
+  export: [locals_without_parens: export_locals_without_parens]
+]


### PR DESCRIPTION
This file will not be used yet for formatting Plug as Elixir v1.6 (which includes `"mix format"`) is not out yet.

The rationale for only putting `forward/2,3,4` in the exported functions instead of also `get`, `post`, and friends, is that `forward` doesn't take a `do` block. I think it's fine to have

```elixir
get("/foo", do: ...)
```

as if you want it without parens, you can go with

```elixir
get "/foo" do
  ...
end
```
