### PR TITLE
Allow JSON decoder can be passed as a function

### DIFF
--- a/lib/plug/parsers/json.ex
+++ b/lib/plug/parsers/json.ex
@@ -43,6 +43,17 @@ defmodule Plug.Parsers.JSON do
     {:ok, %{}, conn}
   end
 
+  defp decode({:ok, body, conn}, decoding_fun) when is_function(decoding_fun) do
+    case decoding_fun.(body) do
+      terms when is_map(terms) ->
+        {:ok, terms, conn}
+      terms ->
+        {:ok, %{"_json" => terms}, conn}
+    end
+  rescue
+    e -> raise Plug.Parsers.ParseError, exception: e
+  end
+
   defp decode({:ok, body, conn}, decoder) do
     case decoder.decode!(body) do
       terms when is_map(terms) ->

--- a/test/plug/parsers/json_test.exs
+++ b/test/plug/parsers/json_test.exs
@@ -47,6 +47,11 @@ defmodule Plug.Parsers.JSONTest do
     assert conn.params["id"] == 1
   end
 
+  test "parses with decoder as a function" do
+    conn = "{id: 1}" |> json_conn() |> parse([json_decoder: &JSON.decode!/1])
+    assert conn.params["id"] == 1
+  end
+
   test "expects a json encoder" do
     assert_raise ArgumentError, "JSON parser expects a :json_decoder option", fn ->
       nil |> json_conn() |> parse(json_decoder: nil)


### PR DESCRIPTION
This PR enables user to pass JSON decoder as a function to `Plug.Parsers.JSON`.

I think this would make it more flexible for users to configure the way of decoding JSON. For example to pass extra options to `Poison.decode!/2`, instead of creating a new module, a simple function would do.

```
plug Plug.Parsers, parsers: [:urlencoded, :json],
                   pass:  ["text/*"],
                   json_decoder: fn body -> Poison.decode!(body, as: %User{}) end
```