### PR TITLE
Allow passing MFA tuple to JSON decoder

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -108,6 +108,9 @@ defmodule Plug.Parsers do
       plug Plug.Parsers, parsers: [:urlencoded, :json],
                          pass:  ["text/*"],
                          json_decoder: Poison
+      plug Plug.Parsers, parsers: [:urlencoded, :json],
+                         pass:  ["text/*"],
+                         json_decoder: {Poison, :decode!, [[as: %User{}]]}
 
   ## Built-in parsers
 

--- a/lib/plug/parsers/json.ex
+++ b/lib/plug/parsers/json.ex
@@ -44,7 +44,7 @@ defmodule Plug.Parsers.JSON do
   end
 
   defp decode({:ok, body, conn}, {module_name, function_name, extra_args}) do
-    case apply(module_name, function_name, [body, extra_args]) do
+    case apply(module_name, function_name, [body | extra_args]) do
       terms when is_map(terms) ->
         {:ok, terms, conn}
       terms ->

--- a/lib/plug/parsers/json.ex
+++ b/lib/plug/parsers/json.ex
@@ -43,6 +43,17 @@ defmodule Plug.Parsers.JSON do
     {:ok, %{}, conn}
   end
 
+  defp decode({:ok, body, conn}, decoding_fun) when is_function(decoding_fun) do
+    case decoding_fun.(body) do
+      terms when is_map(terms) ->
+        {:ok, terms, conn}
+      terms ->
+        {:ok, %{"_json" => terms}, conn}
+    end
+  rescue
+    e -> raise Plug.Parsers.ParseError, exception: e
+  end
+
   defp decode({:ok, body, conn}, decoder) do
     case decoder.decode!(body) do
       terms when is_map(terms) ->

--- a/lib/plug/parsers/json.ex
+++ b/lib/plug/parsers/json.ex
@@ -43,8 +43,8 @@ defmodule Plug.Parsers.JSON do
     {:ok, %{}, conn}
   end
 
-  defp decode({:ok, body, conn}, decoding_fun) when is_function(decoding_fun) do
-    case decoding_fun.(body) do
+  defp decode({:ok, body, conn}, {module_name, function_name, extra_args}) do
+    case apply(module_name, function_name, [body, extra_args]) do
       terms when is_map(terms) ->
         {:ok, terms, conn}
       terms ->

--- a/test/plug/parsers/json_test.exs
+++ b/test/plug/parsers/json_test.exs
@@ -14,6 +14,10 @@ defmodule Plug.Parsers.JSONTest do
     def decode!(_) do
       raise "oops"
     end
+
+    def decode!("{id: 1}", capitalize_keys: true) do
+      %{"ID" => 1}
+    end
   end
 
   def json_conn(body, content_type \\ "application/json") do
@@ -47,9 +51,9 @@ defmodule Plug.Parsers.JSONTest do
     assert conn.params["id"] == 1
   end
 
-  test "parses with decoder as a function" do
-    conn = "{id: 1}" |> json_conn() |> parse([json_decoder: &JSON.decode!/1])
-    assert conn.params["id"] == 1
+  test "parses with decoder as a MFA argument" do
+    conn = "{id: 1}" |> json_conn() |> parse([json_decoder: {JSON, :decode!, [capitalize_keys: true]}])
+    assert conn.params["ID"] == 1
   end
 
   test "expects a json encoder" do

--- a/test/plug/parsers/json_test.exs
+++ b/test/plug/parsers/json_test.exs
@@ -52,7 +52,7 @@ defmodule Plug.Parsers.JSONTest do
   end
 
   test "parses with decoder as a MFA argument" do
-    conn = "{id: 1}" |> json_conn() |> parse([json_decoder: {JSON, :decode!, [capitalize_keys: true]}])
+    conn = "{id: 1}" |> json_conn() |> parse([json_decoder: {JSON, :decode!, [[capitalize_keys: true]]}])
     assert conn.params["ID"] == 1
   end
 

--- a/test/plug/parsers/json_test.exs
+++ b/test/plug/parsers/json_test.exs
@@ -47,6 +47,11 @@ defmodule Plug.Parsers.JSONTest do
     assert conn.params["id"] == 1
   end
 
+  test "parses with decoder as a function" do
+    conn = "{id: 1}" |> json_conn() |> parse([json_decoder: &JSON.decode!/1])
+    assert conn.params["id"] == 1
+  end
+
   test "expects a json encoder" do
     assert_raise ArgumentError, "JSON parser expects a :json_decoder option", fn ->
       nil |> json_conn() |> parse(json_decoder: nil)


### PR DESCRIPTION
Follow up #641.

This PR enables user to pass an MFA tuple to `Plug.Parsers.JSON`.

I think this would make it more flexible for users to configure the way of decoding JSON. For example to pass extra options to `Poison.decode!/2`, instead of creating a new module.

```elixir
plug Plug.Parsers, parsers: [:urlencoded, :json],
                   pass:  ["text/*"],
                   json_decoder: {Poison, :decode!, [as: %User{}]}
```