### PR TITLE
Update Cowboy2.child_spec documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /doc
 erl_crash.dump
 *.ez
+*.ex~


### PR DESCRIPTION
This is just the update to the Cowboy2.child_spec() documentation so that the example uses the child_spec function.