### PR TITLE
Add a prepend_resp_headers/3 to Plug.Conn

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -655,8 +655,7 @@ defmodule Plug.Conn do
 
   @doc ~S"""
   Similar to `put_resp_header` this functions adds a new response header (`key`)
-  if not present, otherwise it wont replace the existing header with `key` but
-  rather add another header with the same `key`.
+  but rather then replacing the exising one it appends another header with the same `key`.
 
   It is recommended for header keys to be in lower-case, to avoid sending
   duplicate keys in a request. As a convenience, this is validated during

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -668,19 +668,22 @@ defmodule Plug.Conn do
   Raises a `Plug.Conn.InvalidHeaderError` if the header value contains control
   feed (`\r`) or newline (`\n`) characters.
   """
-  def prepend_resp_headers(%Conn{state: :sent}, _key, _value) do
+  def prepend_resp_headers(%Conn{state: :sent}, _headers) do
     raise AlreadySentError
   end
 
-  def prepend_resp_headers(%Conn{state: :chunked}, _key, _value) do
+  def prepend_resp_headers(%Conn{state: :chunked}, _headers) do
     raise AlreadySentError
   end
 
-  def prepend_resp_headers(%Conn{adapter: adapter, resp_headers: headers} = conn, key, value)
-      when is_binary(key) and is_binary(value) do
-    validate_header_key_if_test!(adapter, key)
-    validate_header_value!(key, value)
-    %{conn | resp_headers: [{key, value} | headers]}
+  def prepend_resp_headers(%Conn{adapter: adapter, resp_headers: resp_headers} = conn, headers)
+      when is_list(headers) do
+    for {key, value} <- headers do
+      validate_header_key_if_test!(adapter, key)
+      validate_header_value!(key, value)
+    end
+
+    %{conn | resp_headers: headers ++ resp_headers}
   end
 
   @doc """

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -668,6 +668,7 @@ defmodule Plug.Conn do
   Raises a `Plug.Conn.InvalidHeaderError` if the header value contains control
   feed (`\r`) or newline (`\n`) characters.
   """
+  @spec prepend_resp_headers(t, headers) :: t
   def prepend_resp_headers(%Conn{state: :sent}, _headers) do
     raise AlreadySentError
   end

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -654,8 +654,11 @@ defmodule Plug.Conn do
   end
 
   @doc ~S"""
-  Similar to `put_resp_header` this functions adds a new response header (`key`)
-  but rather then replacing the exising one it appends another header with the same `key`.
+  Prepends the list of headers to the connection response headers.
+
+  Similar to `put_resp_header` this functions adds a new response header
+  (`key`) but rather then replacing the exising one it prepends another header
+  with the same `key`.
 
   It is recommended for header keys to be in lower-case, to avoid sending
   duplicate keys in a request. As a convenience, this is validated during

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -635,7 +635,7 @@ defmodule Plug.Conn do
   `:sent` or `:chunked`.
 
   Raises a `Plug.Conn.InvalidHeaderError` if the header value contains control
-  feed (\r) or newline (\n) characters.
+  feed (`\r`) or newline (`\n`) characters.
   """
   @spec put_resp_header(t, binary, binary) :: t
   def put_resp_header(%Conn{state: :sent}, _key, _value) do
@@ -667,7 +667,7 @@ defmodule Plug.Conn do
   `:sent` or `:chunked`.
 
   Raises a `Plug.Conn.InvalidHeaderError` if the header value contains control
-  feed (\r) or newline (\n) characters.
+  feed (`\r`) or newline (`\n`) characters.
   """
   def prepend_resp_headers(%Conn{state: :sent}, _key, _value) do
     raise AlreadySentError

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -681,7 +681,7 @@ defmodule Plug.Conn do
       when is_binary(key) and is_binary(value) do
     validate_header_key_if_test!(adapter, key)
     validate_header_value!(key, value)
-    %{conn | resp_headers: [ {key, value} | headers]}
+    %{conn | resp_headers: [{key, value} | headers]}
   end
 
   @doc """

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -471,57 +471,57 @@ defmodule Plug.ConnTest do
     end
   end
 
-  test "prepend_resp_headers/3" do
-    conn1 = prepend_resp_headers(conn(:head, "/foo"), "x-foo", "bar")
+  test "prepend_resp_headers/2" do
+    conn1 = prepend_resp_headers(conn(:head, "/foo"), [{"x-foo", "bar"}])
     assert get_resp_header(conn1, "x-foo") == ["bar"]
-    conn2 = prepend_resp_headers(conn1, "x-foo", "baz")
+    conn2 = prepend_resp_headers(conn1, [{"x-foo", "baz"}])
     assert get_resp_header(conn2, "x-foo") == ["baz", "bar"]
   end
 
-  test "prepend_resp_headers/3 raises when the conn was already been sent" do
+  test "prepend_resp_headers/2 raises when the conn was already been sent" do
     conn = send_resp(conn(:get, "/foo"), 200, "ok")
 
     assert_raise Plug.Conn.AlreadySentError, fn ->
-      prepend_resp_headers(conn, "x-foo", "bar")
+      prepend_resp_headers(conn, [{"x-foo", "bar"}])
     end
   end
 
-  test "prepend_resp_headers/3 raises when the conn is chunked" do
+  test "prepend_resp_headers/2 raises when the conn is chunked" do
     conn = send_chunked(conn(:get, "/foo"), 200)
 
     assert_raise Plug.Conn.AlreadySentError, fn ->
-      prepend_resp_headers(conn, "x-foo", "bar")
+      prepend_resp_headers(conn, [{"x-foo", "bar"}])
     end
   end
 
-  test "prepend_resp_headers/3 raises when invalid header key given" do
+  test "prepend_resp_headers/2 raises when invalid header key given" do
     Application.put_env(:plug, :validate_header_keys_during_test, true)
     conn = conn(:get, "/foo")
 
     assert_raise Plug.Conn.InvalidHeaderError, ~S[header key is not lowercase: "X-Foo"], fn ->
-      prepend_resp_headers(conn, "X-Foo", "bar")
+      prepend_resp_headers(conn, [{"X-Foo", "bar"}])
     end
   end
 
-  test "prepend_resp_headers/3 doesn't raise with invalid header key given when :validate_header_keys_during_test is disabled" do
+  test "prepend_resp_headers/2 doesn't raise with invalid header key given when :validate_header_keys_during_test is disabled" do
     Application.put_env(:plug, :validate_header_keys_during_test, false)
     conn = conn(:get, "/foo")
-    prepend_resp_headers(conn, "X-Foo", "bar")
+    prepend_resp_headers(conn, [{"X-Foo", "bar"}])
   end
 
-  test "prepend_resp_headers/3 raises when invalid header value given" do
+  test "prepend_resp_headers/2 raises when invalid header value given" do
     message =
       ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\rBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
-      prepend_resp_headers(conn(:get, "foo"), "x-sample", "value\rBAR")
+      prepend_resp_headers(conn(:get, "foo"), [{"x-sample", "value\rBAR"}])
     end
 
     message =
       ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\n\nBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
-      prepend_resp_headers(conn(:get, "foo"), "x-sample", "value\n\nBAR")
+      prepend_resp_headers(conn(:get, "foo"), [{"x-sample", "value\n\nBAR"}])
     end
   end
 

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -471,6 +471,60 @@ defmodule Plug.ConnTest do
     end
   end
 
+  test "prepend_resp_headers/3" do
+    conn1 = prepend_resp_headers(conn(:head, "/foo"), "x-foo", "bar")
+    assert get_resp_header(conn1, "x-foo") == ["bar"]
+    conn2 = prepend_resp_headers(conn1, "x-foo", "baz")
+    assert get_resp_header(conn2, "x-foo") == ["baz", "bar"]
+  end
+
+  test "prepend_resp_headers/3 raises when the conn was already been sent" do
+    conn = send_resp(conn(:get, "/foo"), 200, "ok")
+
+    assert_raise Plug.Conn.AlreadySentError, fn ->
+      prepend_resp_headers(conn, "x-foo", "bar")
+    end
+  end
+
+  test "prepend_resp_headers/3 raises when the conn is chunked" do
+    conn = send_chunked(conn(:get, "/foo"), 200)
+
+    assert_raise Plug.Conn.AlreadySentError, fn ->
+      prepend_resp_headers(conn, "x-foo", "bar")
+    end
+  end
+
+  test "prepend_resp_headers/3 raises when invalid header key given" do
+    Application.put_env(:plug, :validate_header_keys_during_test, true)
+    conn = conn(:get, "/foo")
+
+    assert_raise Plug.Conn.InvalidHeaderError, ~S[header key is not lowercase: "X-Foo"], fn ->
+      prepend_resp_headers(conn, "X-Foo", "bar")
+    end
+  end
+
+  test "prepend_resp_headers/3 doesn't raise with invalid header key given when :validate_header_keys_during_test is disabled" do
+    Application.put_env(:plug, :validate_header_keys_during_test, false)
+    conn = conn(:get, "/foo")
+    prepend_resp_headers(conn, "X-Foo", "bar")
+  end
+
+  test "prepend_resp_headers/3 raises when invalid header value given" do
+    message =
+      ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\rBAR"]
+
+    assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
+      prepend_resp_headers(conn(:get, "foo"), "x-sample", "value\rBAR")
+    end
+
+    message =
+      ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\n\nBAR"]
+
+    assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
+      prepend_resp_headers(conn(:get, "foo"), "x-sample", "value\n\nBAR")
+    end
+  end
+
   test "merge_resp_header/3 raises when invalid header value given" do
     message =
       ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\rBAR"]


### PR DESCRIPTION
At the moment when you want to add another header with an existing key, you would need to manipulate the connections response_headers manually, thus bypassing all internal checks.

This PR adds a function that gives a way of doing this through the public API of Plug.Conn.

this PR fixes #660