### PR TITLE
Deprecate Plug.Conn's Collectable protocol implementation

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1356,6 +1356,30 @@ end
 
 defimpl Collectable, for: Plug.Conn do
   def into(conn) do
+    IO.puts(
+      :stderr,
+      """
+      warning: using Enum.into/2 for conn is deprecated, use Enum.reduce_while/3 instead:
+
+      To stream data use `Enum.reduce_while/3` instead of `Enum.into/2`.
+      `Enum.reduce_while/3` allows aborting the execution if `chunk/2` fails to
+      deliver the chunk of data.
+
+      ## Example
+
+          ~w(each chunk as a word)
+          |> Enum.reduce_while(conn, fn (chunk, conn) ->
+            case Plug.Conn.chunk(conn, chunk) do
+              {:ok, conn} ->
+                {:cont, conn}
+              {:error, :closed} ->
+                {:halt, conn}
+            end
+          end)
+
+      """
+    )
+
     fun = fn
       conn, {:cont, x} ->
         {:ok, conn} = Plug.Conn.chunk(conn, x)

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1382,7 +1382,7 @@ defimpl Collectable, for: Plug.Conn do
       `Enum.reduce_while/3` allows aborting the execution if `chunk/2` fails to
       deliver the chunk of data.
 
-      ## Example
+      Example
 
           ~w(each chunk as a word)
           |> Enum.reduce_while(conn, fn (chunk, conn) ->

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -475,6 +475,23 @@ defmodule Plug.Conn do
   It expects a connection with state `:chunked` as set by
   `send_chunked/2`. It returns `{:ok, conn}` in case of success,
   otherwise `{:error, reason}`.
+
+  To stream data use `Enum.reduce_while/3` instead of `Enum.into/2`.
+  `Enum.reduce_while/3` allows aborting the execution if `chunk/2` fails to
+  deliver the chunk of data.
+
+  ## Example
+
+      ~w(each chunk as a word)
+      |> Enum.reduce_while(conn, fn (chunk, conn) ->
+        case Plug.Conn.chunk(conn, chunk) do
+          {:ok, conn} ->
+            {:cont, conn}
+          {:error, :closed} ->
+            {:halt, conn}
+        end
+      end)
+
   """
   @spec chunk(t, body) :: {:ok, t} | {:error, term} | no_return
   def chunk(%Conn{adapter: {adapter, payload}, state: :chunked} = conn, chunk) do

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1373,29 +1373,26 @@ end
 
 defimpl Collectable, for: Plug.Conn do
   def into(conn) do
-    IO.puts(
-      :stderr,
-      """
-      warning: using Enum.into/2 for conn is deprecated, use Enum.reduce_while/3 instead:
+    IO.puts(:stderr, """
+    warning: using Enum.into/2 for conn is deprecated, use Enum.reduce_while/3 instead:
 
-      To stream data use `Enum.reduce_while/3` instead of `Enum.into/2`.
-      `Enum.reduce_while/3` allows aborting the execution if `chunk/2` fails to
-      deliver the chunk of data.
+    To stream data use `Enum.reduce_while/3` instead of `Enum.into/2`.
+    `Enum.reduce_while/3` allows aborting the execution if `chunk/2` fails to
+    deliver the chunk of data.
 
-      Example
+    Example
 
-          ~w(each chunk as a word)
-          |> Enum.reduce_while(conn, fn (chunk, conn) ->
-            case Plug.Conn.chunk(conn, chunk) do
-              {:ok, conn} ->
-                {:cont, conn}
-              {:error, :closed} ->
-                {:halt, conn}
-            end
-          end)
+        ~w(each chunk as a word)
+        |> Enum.reduce_while(conn, fn (chunk, conn) ->
+          case Plug.Conn.chunk(conn, chunk) do
+            {:ok, conn} ->
+              {:cont, conn}
+            {:error, :closed} ->
+              {:halt, conn}
+          end
+        end)
 
-      """
-    )
+    """)
 
     fun = fn
       conn, {:cont, x} ->

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -5,6 +5,8 @@ defmodule Plug.ConnTest do
   alias Plug.Conn
   alias Plug.ProcessStore
 
+  import ExUnit.CaptureIO
+
   test "test adapter builds on connection" do
     conn =
       Plug.Adapters.Test.Conn.conn(%Plug.Conn{private: %{hello: :world}}, :post, "/hello", nil)
@@ -360,8 +362,10 @@ defmodule Plug.ConnTest do
 
   test "send_chunked/3 with collectable" do
     conn = send_chunked(conn(:get, "/foo"), 200)
-    conn = Enum.into(~w(hello world), conn)
-    assert conn.resp_body == "helloworld"
+    capture_io(:stderr, fn ->
+      conn = Enum.into(~w(hello world), conn)
+      assert conn.resp_body == "helloworld"
+    end)
   end
 
   test "send_chunked/3 sends self a message" do

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -362,6 +362,7 @@ defmodule Plug.ConnTest do
 
   test "send_chunked/3 with collectable" do
     conn = send_chunked(conn(:get, "/foo"), 200)
+
     capture_io(:stderr, fn ->
       conn = Enum.into(~w(hello world), conn)
       assert conn.resp_body == "helloworld"


### PR DESCRIPTION
This PR addresses the issue raised here https://github.com/elixir-plug/plug/issues/669.

The Plug.Conn's implementation of the Collectable protocol allows to stream traverse a collection of data into `conn`. The issue with it is that it does not take into consideration when something goes wrong while delivering a chunk of data and raises an error instead of terminating gracefully.  See here: [conn.ex#L1361](https://github.com/elixir-plug/plug/blob/master/lib/plug/conn.ex#L1361)

The conclusion is that it's better to deprecate the protocol implementation and suggest the use of `Enum.reduce_while/3` to traverse a collection of data into `conn`:

```elixir
~w(each chunk as a word)
|> Enum.reduce_while(conn, fn (chunk, conn) ->
  case Plug.Conn.chunk(conn, chunk) do
    {:ok, conn} ->
      {:cont, conn}
    {:error, :closed} ->
      # Client closed the connection
      {:halt, conn}
  end
end)
```