### PR TITLE
Redirect on x-forwarded-proto whatever the scheme

### DIFF
--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -72,10 +72,10 @@ defmodule Plug.SSL do
   defp rewrite_on(conn, rewrites) do
     Enum.reduce(rewrites, conn, fn
       :x_forwarded_proto, acc ->
-        if get_req_header(acc, "x-forwarded-proto") == ["https"] do
-          %{acc | scheme: :https}
-        else
-          acc
+        case get_req_header(acc, "x-forwarded-proto") do
+          ["https"] -> %{acc | scheme: :https}
+          ["http"] -> %{acc | scheme: :http}
+          _ -> acc
         end
 
       other, _acc ->

--- a/test/plug/ssl_test.exs
+++ b/test/plug/ssl_test.exs
@@ -74,6 +74,24 @@ defmodule Plug.SSLTest do
     assert conn.halted
   end
 
+  test "redirects to host when secure" do
+    conn =
+      conn(:get, "https://example.com/")
+      |> put_req_header("x-forwarded-proto", "http")
+      |> call(rewrite_on: [:x_forwarded_proto])
+
+    assert get_resp_header(conn, "location") == ["https://example.com/"]
+    assert conn.halted
+
+    conn =
+      conn(:get, "https://example.com/foo?bar=baz")
+      |> put_req_header("x-forwarded-proto", "http")
+      |> call(rewrite_on: [:x_forwarded_proto])
+
+    assert get_resp_header(conn, "location") == ["https://example.com/foo?bar=baz"]
+    assert conn.halted
+  end
+
   test "redirects to custom host on get" do
     conn = call(conn(:get, "http://example.com/"), host: "ssl.example.com:443")
     assert get_resp_header(conn, "location") == ["https://ssl.example.com:443/"]


### PR DESCRIPTION
Today Plug.SSL only redirects HTTP to HTTPS if the connection to the app
is unsecure. If the app is behind the proxy, the connection between the
proxy and the app can be secure (HTTPS) but x-forwarded-proto can still
be set to HTTP.

In such case, we should redirect.

Closes https://github.com/elixir-plug/plug/issues/674