### PR TITLE
Make the adapter contract for push return :ok or {:error, reason}

### DIFF
--- a/lib/plug/adapters/cowboy2/conn.ex
+++ b/lib/plug/adapters/cowboy2/conn.ex
@@ -79,7 +79,6 @@ defmodule Plug.Adapters.Cowboy2.Conn do
       end
 
     :cowboy_req.push(path, to_headers_map(headers), req, opts)
-    {:ok, req}
   end
 
   ## Helpers

--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -19,7 +19,6 @@ defmodule Plug.Adapters.Test.Conn do
       method: method,
       params: params,
       req_body: body,
-      pushes: [],
       chunks: nil,
       ref: make_ref(),
       owner: owner
@@ -103,8 +102,9 @@ defmodule Plug.Adapters.Test.Conn do
     {tag, data, %{state | req_body: rest}}
   end
 
-  def push(%{pushes: pushes} = state, path, headers) do
-    {:ok, %{state | pushes: [{path, headers} | pushes]}}
+  def push(%{owner: owner, ref: ref}, path, headers) do
+    send(owner, {ref, :push, {path, headers}})
+    :ok
   end
 
   ## Private helpers

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1045,11 +1045,9 @@ defmodule Plug.Conn do
   If the adapter does not support server push then this is a noop.
   """
   @spec push(t, String.t(), Keyword.t()) :: t
-  def push(%Conn{adapter: {adapter, _}} = conn, path, headers \\ []) do
-    case adapter_push(conn, path, headers) do
-      {:ok, payload} -> %{conn | adapter: {adapter, payload}}
-      _ -> conn
-    end
+  def push(%Conn{} = conn, path, headers \\ []) do
+    adapter_push(conn, path, headers)
+    conn
   end
 
   @doc """
@@ -1059,8 +1057,8 @@ defmodule Plug.Conn do
   @spec push!(t, String.t(), Keyword.t()) :: t
   def push!(%Conn{adapter: {adapter, _}} = conn, path, headers \\ []) do
     case adapter_push(conn, path, headers) do
-      {:ok, payload} ->
-        %{conn | adapter: {adapter, payload}}
+      :ok ->
+        conn
 
       _ ->
         raise "server push not supported by #{inspect(adapter)}." <>

--- a/lib/plug/conn/adapter.ex
+++ b/lib/plug/conn/adapter.ex
@@ -84,6 +84,5 @@ defmodule Plug.Conn.Adapter do
   If the adapter does not support server push then `{:error, :not_supported}`
   should be returned.
   """
-  @callback push(payload, path :: String.t(), headers :: Keyword.t()) ::
-              {:ok, payload} | {:error, term}
+  @callback push(payload, path :: String.t(), headers :: Keyword.t()) :: :ok | {:error, term}
 end

--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -95,6 +95,18 @@ defmodule Plug.Test do
 
   @doc """
   Return the assets that have been pushed.
+
+  This function depends on gathering the messages sent by the test adapter
+  when assets are pushed. Calling this function will clear the pushed message
+  from the inbox for the process. To assert on multiple pushes, the result
+  of the function should be stored in a variable.
+
+  ## Examples
+
+      conn = conn(:get, "/foo", "bar=10")
+      pushes = Plug.Test.sent_pushes(conn)
+      assert {"/static/application.css", [{"accept", "text/css"}]} in pushes
+      assert {"/static/application.js", [{"accept", "application/javascript"}]} in pushes
   """
   def sent_pushes(%Conn{adapter: {Plug.Adapters.Test.Conn, %{ref: ref}}}) do
     Enum.reverse(receive_pushes(ref, []))

--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -96,8 +96,17 @@ defmodule Plug.Test do
   @doc """
   Return the assets that have been pushed.
   """
-  def sent_pushes(%Conn{adapter: {Plug.Adapters.Test.Conn, %{pushes: pushes}}}) do
-    Enum.reverse(pushes)
+  def sent_pushes(%Conn{adapter: {Plug.Adapters.Test.Conn, %{ref: ref}}}) do
+    Enum.reverse(receive_pushes(ref, []))
+  end
+
+  defp receive_pushes(ref, pushes) do
+    receive do
+      {^ref, :push, response} ->
+        receive_pushes(ref, [response | pushes])
+    after
+      0 -> pushes
+    end
   end
 
   @doc """


### PR DESCRIPTION
Since the adapters all use side-effects for push, there is no transformation in
the payload - allowing the original conn to be returned. To maek this explicit,
the contract for `Plug.Adapter` does not allow a transformed payload to be
returned.

To comply with this change, the test adapter has been updated to send a message
on push, and gather the messages when sent_pushes/1 is called.

To ensure that the push messages aren't caught when gathering the response
messages, a 3 tuple of `{ref, :push, asset}` is used.