### PR TITLE
Fix CSRF Plug doc with missing backtick

### DIFF
--- a/lib/plug/csrf_protection.ex
+++ b/lib/plug/csrf_protection.ex
@@ -55,7 +55,7 @@ defmodule Plug.CSRFProtection do
   For example, if you are running your application behind a proxy, the browser
   will send a request to the proxy with `www.example.com` but the proxy will
   request you using an internal IP. In such cases, it is common for proxies
-  to attach information such as `"x-forwarded-host" that contains the original
+  to attach information such as `"x-forwarded-host"` that contains the original
   host.
 
   This may also happen on redirects. If you have a POST request to `foo.example.com`


### PR DESCRIPTION
this will fix a rather unpleaseant text rendering at [CSRF plug docs](https://hexdocs.pm/plug/Plug.CSRFProtection.html#content)

![before](https://user-images.githubusercontent.com/4076473/37281238-ae5ef5b6-25f0-11e8-97fb-ef7a83623216.png)
