### PR TITLE
Implement missing access behaviour for Plug.Conn.Unfetched

### DIFF
--- a/lib/plug/conn/unfetched.ex
+++ b/lib/plug/conn/unfetched.ex
@@ -13,15 +13,30 @@ defmodule Plug.Conn.Unfetched do
   defstruct [:aspect]
   @type t :: %__MODULE__{aspect: atom()}
 
-  @doc false
-  def get(%{aspect: aspect}, key, _value) do
-    raise ArgumentError,
-          "cannot get key #{inspect(key)} from conn.#{aspect} because they were not fetched"
+  @behaviour Access
+
+  @impl true
+  def fetch(%{aspect: aspect}, key) do
+    raise_unfetched(__ENV__.function, aspect, key)
   end
 
-  @doc false
+  @impl true
+  def get(%{aspect: aspect}, key, _value) do
+    raise_unfetched(__ENV__.function, aspect, key)
+  end
+
+  @impl true
   def get_and_update(%{aspect: aspect}, key, _fun) do
+    raise_unfetched(__ENV__.function, aspect, key)
+  end
+
+  @impl true
+  def pop(%{aspect: aspect}, key) do
+    raise_unfetched(__ENV__.function, aspect, key)
+  end
+
+  defp raise_unfetched({access, _}, aspect, key) do
     raise ArgumentError,
-          "cannot get_and_update key #{inspect(key)} from conn.#{aspect} because they were not fetched"
+          "cannot #{access} key #{inspect(key)} from conn.#{aspect} because they were not fetched"
   end
 end

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -1123,4 +1123,10 @@ defmodule Plug.ConnTest do
       Conn.send_resp(%Plug.Conn{}, 200, "Hello World")
     end
   end
+
+  test "dynamic access on unfetched fields" do
+    assert_raise ArgumentError, ~r/cannot fetch key \"bar\"/, fn ->
+      conn(:get, "/foo?bar=baz").query_params["bar"]
+    end
+  end
 end


### PR DESCRIPTION
Dynamic access on unfetched `Plug.Conn` fields currently yields a no Access behaviour exception:

```
conn.query_params["foo"]

** (UndefinedFunctionError) function Plug.Conn.Unfetched.fetch/2 is undefined (Plug.Conn.Unfetched does not implement the Access behaviour)
```

I believe it is intended to be the `ArgumentError` currently raised in `Plug.Conn.Unfetched.get/1`. 
If so, this pull implements the full `Access` behaviour for `Plug.Conn.Unfetched`.

:)