### PR TITLE
Add function plug forwarding to Plug.Router

### DIFF
--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -377,8 +377,14 @@ defmodule Plug.Router do
         raise ArgumentError, message: "expected :to to be an alias or an atom"
       end
 
+      {target, target_opts} =
+        case Atom.to_string(target) do
+          "Elixir." <> _ -> {target, target.init(plug_options)}
+          _ -> {{__MODULE__, target}, plug_options}
+        end
+
       @plug_forward_target target
-      @plug_forward_opts target.init(plug_options)
+      @plug_forward_opts target_opts
 
       # Delegate the matching to the match/3 macro along with the options
       # specified by Keyword.split/2.

--- a/lib/plug/router/utils.ex
+++ b/lib/plug/router/utils.ex
@@ -88,9 +88,13 @@ defmodule Plug.Router.Utils do
   """
   def forward(%Plug.Conn{path_info: path, script_name: script} = conn, new_path, target, opts) do
     {base, split_path} = Enum.split(path, length(path) - length(new_path))
-    conn = target.call(%{conn | path_info: split_path, script_name: script ++ base}, opts)
+
+    conn = do_forward(target, %{conn | path_info: split_path, script_name: script ++ base}, opts)
     %{conn | path_info: path, script_name: script}
   end
+
+  defp do_forward({mod, fun}, conn, opts), do: apply(mod, fun, [conn, opts])
+  defp do_forward(mod, conn, opts), do: mod.call(conn, opts)
 
   @doc """
   Splits the given path into several segments.

--- a/test/plug/router_test.exs
+++ b/test/plug/router_test.exs
@@ -154,6 +154,13 @@ defmodule Plug.RouterTest do
     forward "/plug/forward", to: SamplePlug
     forward "/plug/init_opts", to: plug, init_opts: opts, private: %{baz: :qux}
 
+    forward "/plug/forward_local", to: :forward_local
+    forward "/plug/forward_local_opts", to: :forward_local, init_opts: opts, private: %{baz: :qux}
+
+    def forward_local(conn, opts) do
+      resp(conn, 200, "#{inspect(opts)}")
+    end
+
     match _ do
       resp(conn, 404, "oops")
     end
@@ -428,6 +435,17 @@ defmodule Plug.RouterTest do
     conn = call(Sample, conn(:get, "/plug/init_opts"))
     assert conn.private[:baz] == :qux
     assert conn.resp_body == ":world"
+  end
+
+  test "forwards to a function plug" do
+    conn = call(Sample, conn(:get, "/plug/forward_local"))
+    assert conn.resp_body == "[]"
+  end
+
+  test "forwards to a function plug with options" do
+    conn = call(Sample, conn(:get, "/plug/forward_local_opts"))
+    assert conn.private[:baz] == :qux
+    assert conn.resp_body == ":hello"
   end
 
   defp call(mod, conn) do


### PR DESCRIPTION
The docs state that `Plug.Router.forward/2` can be passed a function plug:

`forward "/foo/bar", to: :foo_bar_plug`

However only module plugs were getting dispatched.
Hopefully now solved :)