### PR TITLE
Remove @impl from Plug.Conn.Unfetched

### DIFF
--- a/lib/plug/conn/unfetched.ex
+++ b/lib/plug/conn/unfetched.ex
@@ -15,22 +15,18 @@ defmodule Plug.Conn.Unfetched do
 
   @behaviour Access
 
-  @impl true
   def fetch(%{aspect: aspect}, key) do
     raise_unfetched(__ENV__.function, aspect, key)
   end
 
-  @impl true
   def get(%{aspect: aspect}, key, _value) do
     raise_unfetched(__ENV__.function, aspect, key)
   end
 
-  @impl true
   def get_and_update(%{aspect: aspect}, key, _fun) do
     raise_unfetched(__ENV__.function, aspect, key)
   end
 
-  @impl true
   def pop(%{aspect: aspect}, key) do
     raise_unfetched(__ENV__.function, aspect, key)
   end


### PR DESCRIPTION
Plug supports Elixir v1.3, or at least it's included in the [Travis CI matrix](https://github.com/elixir-plug/plug/blob/master/.travis.yml#L10). `@impl` was introduced in v1.5, so the previous code won't work in all the supported versions.