### PR TITLE
(WIP) Add a custom body reader option to Parsers

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -97,7 +97,7 @@ defmodule Plug.Parsers do
       plug Plug.Parsers, parsers: [:urlencoded, :multipart]
 
       plug Plug.Parsers, parsers: [:urlencoded, :json],
-                         pass:  ["text/*"],
+                         pass: ["text/*"],
                          json_decoder: Jason
 
   Each parser also accepts options to be given directly to it by using tuples.

--- a/lib/plug/parsers/urlencoded.ex
+++ b/lib/plug/parsers/urlencoded.ex
@@ -19,14 +19,14 @@ defmodule Plug.Parsers.URLENCODED do
   """
 
   @behaviour Plug.Parsers
-  alias Plug.Conn
 
   def init(opts) do
-    Keyword.put_new(opts, :length, 1_000_000)
+    opts = Keyword.put_new(opts, :length, 1_000_000)
+    Keyword.pop(opts, :body_reader, {Plug.Conn, :read_body, []})
   end
 
-  def parse(conn, "application", "x-www-form-urlencoded", _headers, opts) do
-    case Conn.read_body(conn, opts) do
+  def parse(conn, "application", "x-www-form-urlencoded", _headers, {{mod, fun, args}, opts}) do
+    case apply(mod, fun, [conn, opts | args]) do
       {:ok, body, conn} ->
         Plug.Conn.Utils.validate_utf8!(body, Plug.Parsers.BadEncodingError, "urlencoded body")
         {:ok, Plug.Conn.Query.decode(body), conn}


### PR DESCRIPTION
Submitting a possible solution as discussed in #691, for further discussion.

Since the body can only be read once, this becomes an issue for anybody who needs the raw body for whatever reason in their application.

This is a common problem and recurring theme that people run into when they need to verify their requests with HTTP Signature Verification. (See [IETF HTTP Signature Verification Draft](https://tools.ietf.org/html/draft-cavage-http-signatures-03)).

This issue effects anybody who uses webhooks to integrate with third-party services like [GitHub](https://developer.github.com/webhooks/securing/), [Stripe](https://stripe.com/docs/webhooks/signatures), [Dropbox](https://www.dropbox.com/developers/reference/webhooks), [Samsung SmartThings](https://smartthings.developer.samsung.com/develop/guides/smartapps/webhook-apps.html#HTTP-signature-verification), and many many more.

By passing in an optional read_body function, the developer can now hook in signature verifications to be used on the raw body before it is discarded.

I'm opening this PR in the hopes of pushing progress on this issue. I am 100% open to completely changing the implementation, and also I will not feel snubbed if somebody opens a better PR.