### PR TITLE
Introduce assign/2 and put_private/2

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -273,7 +273,7 @@ defmodule Plug.Conn do
   @unsent [:unset, :set, :set_chunked, :set_file]
 
   @doc """
-  Assigns a value to a key in the connection
+  Assigns a value to a key in the connection.
 
   ## Examples
 
@@ -287,6 +287,25 @@ defmodule Plug.Conn do
   @spec assign(t, atom, term) :: t
   def assign(%Conn{assigns: assigns} = conn, key, value) when is_atom(key) do
     %{conn | assigns: Map.put(assigns, key, value)}
+  end
+
+  @doc """
+  Assigns multiple values to keys in the connection.
+
+  Equivalent to multiple calls to `assign/3`.
+
+  ## Examples
+
+      iex> conn.assigns[:hello]
+      nil
+      iex> conn = merge_assigns(conn, hello: :world)
+      iex> conn.assigns[:hello]
+      :world
+
+  """
+  @spec merge_assigns(t, Keyword.t()) :: t
+  def merge_assigns(%Conn{assigns: assigns} = conn, keyword) when is_list(keyword) do
+    %{conn | assigns: Enum.into(keyword, assigns)}
   end
 
   @doc false
@@ -327,6 +346,24 @@ defmodule Plug.Conn do
   @spec put_private(t, atom, term) :: t
   def put_private(%Conn{private: private} = conn, key, value) when is_atom(key) do
     %{conn | private: Map.put(private, key, value)}
+  end
+
+  @doc """
+  Assigns multiple **private** keys and values in the connection.
+
+  Equivalent to multiple `put_private/3` calls.
+
+  ## Examples
+
+      iex> conn.private[:plug_hello]
+      nil
+      iex> conn = merge_private(conn, plug_hello: :world)
+      iex> conn.private[:plug_hello]
+      :world
+  """
+  @spec merge_private(t, Keyword.t()) :: t
+  def merge_private(%Conn{private: private} = conn, keyword) when is_list(keyword) do
+    %{conn | private: Enum.into(keyword, private)}
   end
 
   @doc """

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -53,6 +53,13 @@ defmodule Plug.ConnTest do
     assert conn.assigns[:hello] == :world
   end
 
+  test "merge_assigns/2" do
+    conn = conn(:get, "/")
+    assert conn.assigns[:hello] == nil
+    conn = merge_assigns(conn, hello: :world)
+    assert conn.assigns[:hello] == :world
+  end
+
   test "put_status/2" do
     conn = conn(:get, "/")
     assert put_status(conn, nil).status == nil
@@ -76,6 +83,13 @@ defmodule Plug.ConnTest do
     conn = conn(:get, "/")
     assert conn.private[:hello] == nil
     conn = put_private(conn, :hello, :world)
+    assert conn.private[:hello] == :world
+  end
+
+  test "merge_private/2" do
+    conn = conn(:get, "/")
+    assert conn.private[:hello] == nil
+    conn = merge_private(conn, hello: :world)
     assert conn.private[:hello] == :world
   end
 


### PR DESCRIPTION
The keyword versions of `assign/3` and `put_private/3` seem as a very natural extension (it's already partially supported in phoenix in the `render/4` calls in controllers). Additionally, they are more performant than multiple `assign/3` or `put_private/3` calls.