### PR TITLE
Escape apostrophe to predefined entity in Plug.HTML

### DIFF
--- a/lib/plug/html.ex
+++ b/lib/plug/html.ex
@@ -13,7 +13,7 @@ defmodule Plug.HTML do
       "&lt;foo&gt;"
 
       iex> Plug.HTML.html_escape("quotes: \" & \'")
-      "quotes: &quot; &amp; &#39;"
+      "quotes: &quot; &amp; &apos;"
   """
   @spec html_escape(String.t()) :: String.t()
   def html_escape(data) when is_binary(data) do
@@ -30,7 +30,7 @@ defmodule Plug.HTML do
       [[[] | "&lt;"], "foo" | "&gt;"]
 
       iex> Plug.HTML.html_escape_to_iodata("quotes: \" & \'")
-      [[[[], "quotes: " | "&quot;"], " " | "&amp;"], " " | "&#39;"]
+      [[[[], "quotes: " | "&quot;"], " " | "&amp;"], " " | "&apos;"]
 
   """
   @spec html_escape_to_iodata(String.t()) :: iodata
@@ -43,7 +43,7 @@ defmodule Plug.HTML do
     {?>, "&gt;"},
     {?&, "&amp;"},
     {?", "&quot;"},
-    {?', "&#39;"}
+    {?', "&apos;"}
   ]
 
   for {match, insert} <- escapes do

--- a/test/plug/html_test.exs
+++ b/test/plug/html_test.exs
@@ -8,14 +8,14 @@ defmodule Plug.HTMlTest do
     assert html_escape("<script>") == "&lt;script&gt;"
     assert html_escape("html&company") == "html&amp;company"
     assert html_escape("\"quoted\"") == "&quot;quoted&quot;"
-    assert html_escape("html's test") == "html&#39;s test"
+    assert html_escape("html's test") == "html&apos;s test"
   end
 
   test "escapes HTML to iodata" do
     assert iodata_escape("<script>") == "&lt;script&gt;"
     assert iodata_escape("html&company") == "html&amp;company"
     assert iodata_escape("\"quoted\"") == "&quot;quoted&quot;"
-    assert iodata_escape("html's test") == "html&#39;s test"
+    assert iodata_escape("html's test") == "html&apos;s test"
   end
 
   defp iodata_escape(data) do


### PR DESCRIPTION
Apostrophes in XML 1.0 can be escaped as `&apos;`, as defined [here](https://www.w3.org/TR/xml/#sec-predefined-ent).

It's absolutely perfect to escape them to `&#39;` as what `Plug.HTML` is doing now, but I think the escaped output will be more consistent with returning all entity references.