### PR TITLE
fixes for push promise support.

### DIFF
--- a/lib/plug/adapters/cowboy2/conn.ex
+++ b/lib/plug/adapters/cowboy2/conn.ex
@@ -70,7 +70,6 @@ defmodule Plug.Adapters.Cowboy2.Conn do
   def push(req, path, headers) do
     opts =
       case {req.port, req.sock} do
-        {:undefined, {_, port}} when port in [80, 443] -> %{}
         {:undefined, {_, port}} -> %{port: port}
         {port, _} when port in [80, 443] -> %{}
         {port, _} -> %{port: port}

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1058,6 +1058,10 @@ defmodule Plug.Conn do
   will be raised.
 
   If the adapter does not support server push then this is a noop.
+
+  Note that certain browsers (such as Google Chrome) will not accept a pushed
+  resource if your certificate is not trusted. In the case of Chrome this means
+  a valid cert with a SAN. See https://www.chromestatus.com/feature/4981025180483584
   """
   @spec push(t, String.t(), Keyword.t()) :: t
   def push(%Conn{} = conn, path, headers \\ []) do


### PR DESCRIPTION
The goal of this PR is to fix some issues required for Push Promise support and add tests to catch issues that I'm currently experiencing.

First, if using port 443 in development, when the port is undefined in a request the push will fail. A fix is included for this.

Second, Google Chrome will not accept a pushed resource unless the certificate being used is trusted. I've updated the documentation to note this.