### PR TITLE
Fix documentation example for custom body reader in parser

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -155,7 +155,7 @@ defmodule Plug.Parsers do
   body reader that would read the body and store it in the connection, such as:
 
       defmodule CacheBodyReader do
-        def read_body(conn, opts, verified_providers, verifiers) do
+        def read_body(conn, opts) do
           {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
           conn = update_in(conn.assigns[:raw_body], &[body | (&1 || [])])
           {:ok, body, conn}


### PR DESCRIPTION
## Problem
Parser doc's example `read_body` function signature doesn't match its example call.

## Solution
Match them up, opting for the simpler of the two.