### PR TITLE
Provide Capability to opt out of SSL

### DIFF
--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -347,7 +347,7 @@ defmodule Plug.SSL do
   Get runtime config
   """
   def get_opts do
-    opts = Application.get_env(:force_ssl)
+    opts = Application.get_env(:force_ssl, :opts)
     host = Keyword.get(opts, :host)
     rewrite_on = Keyword.get(opts, :rewrite_on, [])
     log = Keyword.get(opts, :log, :info)

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -341,8 +341,16 @@ defmodule Plug.SSL do
   @doc """
   Plug initialization callback.
   """
-  def init([opt_out: true]), do: nil
   def init(opts) do
+    opt_out = Keyword.get(opts, :opt_out, false)
+    get_opts(opt_out, opts)
+  end
+
+  @doc """
+  Plug get opts.
+  """
+  defp get_opts(true, _opts), do: nil
+  defp get_opts(_, opts) do
     host = Keyword.get(opts, :host)
     rewrite_on = Keyword.get(opts, :rewrite_on, [])
     log = Keyword.get(opts, :log, :info)

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -347,6 +347,7 @@ defmodule Plug.SSL do
   end
 
   defp get_opts(true, _opts), do: nil
+
   defp get_opts(_, opts) do
     host = Keyword.get(opts, :host)
     rewrite_on = Keyword.get(opts, :rewrite_on, [])
@@ -359,6 +360,7 @@ defmodule Plug.SSL do
   Plug pipeline callback.
   """
   def call(conn, nil), do: conn
+
   def call(conn, {hsts, exclude, host, rewrites, log_level}) do
     conn = rewrite_on(conn, rewrites)
 

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -341,18 +341,26 @@ defmodule Plug.SSL do
   @doc """
   Plug initialization callback.
   """
-  def init(opts) do
+  def init(opts), do: opts
+
+  @doc """
+  Get runtime config
+  """
+  def get_opts do
+    opts = Application.get_env(:force_ssl)
     host = Keyword.get(opts, :host)
     rewrite_on = Keyword.get(opts, :rewrite_on, [])
     log = Keyword.get(opts, :log, :info)
     exclude = Keyword.get(opts, :exclude, ["localhost"])
+
     {hsts_header(opts), exclude, host, rewrite_on, log}
   end
 
   @doc """
   Plug pipeline callback.
   """
-  def call(conn, {hsts, exclude, host, rewrites, log_level}) do
+  def call(conn, _opts) do
+    {hsts, exclude, host, rewrites, log_level} = get_opts()
     conn = rewrite_on(conn, rewrites)
 
     case conn do

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -347,7 +347,7 @@ defmodule Plug.SSL do
     rewrite_on = Keyword.get(opts, :rewrite_on, [])
     log = Keyword.get(opts, :log, :info)
     exclude = Keyword.get(opts, :exclude, ["localhost"])
-    {hsts_header(opts), exclude, host, rewrite_on, log, opt_out}
+    {hsts_header(opts), exclude, host, rewrite_on, log}
   end
 
   @doc """

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -341,28 +341,25 @@ defmodule Plug.SSL do
   @doc """
   Plug initialization callback.
   """
+  def init([opt_out: true]), do: nil
   def init(opts) do
     host = Keyword.get(opts, :host)
     rewrite_on = Keyword.get(opts, :rewrite_on, [])
     log = Keyword.get(opts, :log, :info)
     exclude = Keyword.get(opts, :exclude, ["localhost"])
-    opt_out = Keyword.get(opts, :opt_out, false)
     {hsts_header(opts), exclude, host, rewrite_on, log, opt_out}
   end
 
   @doc """
   Plug pipeline callback.
   """
-  def call(conn, {hsts, exclude, host, rewrites, log_level, opt_out}) do
-    case opt_out do
-      true -> conn
-      _ ->
-      conn = rewrite_on(conn, rewrites)
+  def call(conn, nil), do: conn
+  def call(conn, {hsts, exclude, host, rewrites, log_level}) do
+    conn = rewrite_on(conn, rewrites)
 
-      case conn do
-        %{scheme: :https} -> put_hsts_header(conn, hsts, exclude)
-        %{} -> redirect_to_https(conn, host, log_level)
-      end
+    case conn do
+      %{scheme: :https} -> put_hsts_header(conn, hsts, exclude)
+      %{} -> redirect_to_https(conn, host, log_level)
     end
   end
 

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -346,7 +346,7 @@ defmodule Plug.SSL do
     rewrite_on = Keyword.get(opts, :rewrite_on, [])
     log = Keyword.get(opts, :log, :info)
     exclude = Keyword.get(opts, :exclude, ["localhost"])
-    force_ssl = Keyword.get(opts, :force_ssl, true)
+    opt_out = Keyword.get(opts, :opt_out, false)
     {hsts_header(opts), exclude, host, rewrite_on, log, force_ssl}
   end
 
@@ -355,7 +355,7 @@ defmodule Plug.SSL do
   """
   def call(conn, {hsts, exclude, host, rewrites, log_level, opt_out}) do
     case opt_out do
-      false -> conn
+      true -> conn
       _ ->
       conn = rewrite_on(conn, rewrites)
 

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -353,8 +353,8 @@ defmodule Plug.SSL do
   @doc """
   Plug pipeline callback.
   """
-  def call(conn, {hsts, exclude, host, rewrites, log_level, force_ssl}) do
-    case force_ssl do
+  def call(conn, {hsts, exclude, host, rewrites, log_level, opt_out}) do
+    case opt_out do
       false -> conn
       _ ->
       conn = rewrite_on(conn, rewrites)

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -346,9 +346,6 @@ defmodule Plug.SSL do
     get_opts(opt_out, opts)
   end
 
-  @doc """
-  Plug get opts.
-  """
   defp get_opts(true, _opts), do: nil
   defp get_opts(_, opts) do
     host = Keyword.get(opts, :host)

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -347,7 +347,7 @@ defmodule Plug.SSL do
     log = Keyword.get(opts, :log, :info)
     exclude = Keyword.get(opts, :exclude, ["localhost"])
     opt_out = Keyword.get(opts, :opt_out, false)
-    {hsts_header(opts), exclude, host, rewrite_on, log, force_ssl}
+    {hsts_header(opts), exclude, host, rewrite_on, log, opt_out}
   end
 
   @doc """


### PR DESCRIPTION
Currently, there is no way to completely opt out of SSL while having Plug.SSL in the pipeline. This will provide the ability to include an `:opt_out` flag in the config. Our use case is building a staging rack (without ssl) with a mix env of prod. We don't want to use a build arg because it would require 2 docker images. We could also achieve this same functionality with a nested plug, but we figured this feature could be useful for others as well.