### PR TITLE
Handle :undefined port

### DIFF
--- a/lib/plug/adapters/translator.ex
+++ b/lib/plug/adapters/translator.ex
@@ -87,6 +87,10 @@ defmodule Plug.Adapters.Translator do
     [server_info(conn), request_info(conn)]
   end
 
+  defp server_info(%Plug.Conn{host: host, port: :undefined, scheme: scheme}) do
+    ["Server: ", host, ?\s, ?(, Atom.to_string(scheme), ?), ?\n]
+  end
+
   defp server_info(%Plug.Conn{host: host, port: port, scheme: scheme}) do
     ["Server: ", host, ":", Integer.to_string(port), ?\s, ?(, Atom.to_string(scheme), ?), ?\n]
   end


### PR DESCRIPTION
I am getting an error 

> Failure while translating Erlang's logger event ** (ArgumentError) argument error     :erlang.integer_to_binary(:undefined)     (plug) lib/plug/adapters/translator.ex:91: Plug.Adapters.Translator.server_info/1     (plug) lib/plug/adapters/translator.ex:87: Plug.Adapters.Translator.conn_info/2     (plug) lib/plug/adapters/translator.ex:59: Plug.Adapters.Translator.translate_ranch/5     (logger) lib/logger/erlang_handler.ex:104: Logger.ErlangHandler.translate/6     (logger) lib/logger/erlang_handler.ex:97: Logger.ErlangHandler.translate/5     (logger) lib/logger/erlang_handler.ex:30: anonymous fn/3 in Logger.ErlangHandler.log/2     (logger) lib/logger.ex:764: Logger.normalize_message/2 

while opening address without a port, e.g. https://example.com. But it's properly formatted with non-default port, e.g. https://example.com:4040

> #PID<0.777.0> running Pult.Router (connection #PID<0.776.0>, stream id 1) terminated Server: localhost:443 (https) Request: GET / ** (exit) an exception was raised:     ** (Plug.Conn.AlreadySentError) the response was already sent         (plug) lib/plug/conn.ex:544: Plug.Conn.resp/3         (plug) lib/plug/conn.ex:531: Plug.Conn.send_resp/3         (pult) lib/pult/router.ex:1: Pult.Router.plug_builder_call/2         (plug) lib/plug/adapters/cowboy2/handler.ex:12: Plug.Adapters.Cowboy2.Handler.init/2         (cowboy) /home/profi/Code/sv/deps/rpi3/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2         (cowboy) /home/profi/Code/sv/deps/rpi3/cowboy/src/cowboy_stream_h.erl:274: :cowboy_stream_h.execute/3         (cowboy) /home/profi/Code/sv/deps/rpi3/cowboy/src/cowboy_stream_h.erl:252: :cowboy_stream_h.request_process/3         (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3

I believe the issue is with Plug.Conn having port :undefined that's not processed here in translator.ex:91 like at https://github.com/elixir-plug/plug/blob/d24ba4f7c859b47866b7031a1ea68469f1808183/lib/plug/adapters/cowboy2/conn.ex#L75.

I am using https://hex.pm/packages/logger_papertrail_backend (however not sure if it has any influence on the issue).