### PR TITLE
Update doc of Plug.Crypto

### DIFF
--- a/lib/plug/crypto.ex
+++ b/lib/plug/crypto.ex
@@ -9,7 +9,7 @@ defmodule Plug.Crypto do
   use Bitwise
 
   @doc """
-  A restricted version a `:erlang.binary_to_term/1` that
+  A restricted version of `:erlang.binary_to_term/2` that
   forbids possibly unsafe terms.
   """
   def safe_binary_to_term(binary, opts \\ []) when is_binary(binary) do


### PR DESCRIPTION
I think that linking `:erlang.binary_to_term/2` makes more sense because the function `Plug.Crypto.safe_binary_to_term/2` forwards all the options to `:erlang.binary_to_term/2`.

As a side note, `:erlang.binary_to_term/2` accepts a `:safe` option, and the name of this function might be misinterpreted (one could think the `:safe` option is being applied). 