### PR TITLE
Fix typo in Plug.Test docs, requsts -> requests

### DIFF
--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -95,7 +95,7 @@ defmodule Plug.Test do
   end
 
   @doc """
-  Return the informational requsts that have been sent.
+  Return the informational requests that have been sent.
 
   This function depends on gathering the messages sent by the test adapter
   when informational messages, such as an early hint, are sent. Calling this function


### PR DESCRIPTION
Found a small typo. Thanks for the lib!