### PR TITLE
Add put_peer_data to Plug.Test

### DIFF
--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -22,6 +22,11 @@ defmodule Plug.Adapters.Test.Conn do
       chunks: nil,
       ref: make_ref(),
       owner: owner,
+      peer_data:
+        case conn.adapter do
+          {Plug.MissingAdapter, _} -> %{address: {127, 0, 0, 1}, port: 111_317, ssl_cert: nil}
+          {adapter, payload} -> adapter.get_peer_data(payload)
+        end,
       http_protocol:
         case conn.adapter do
           {Plug.MissingAdapter, _} -> :"HTTP/1.1"
@@ -116,8 +121,8 @@ defmodule Plug.Adapters.Test.Conn do
     :ok
   end
 
-  def get_peer_data(_state) do
-    %{address: {127, 0, 0, 1}, port: 111_317, ssl_cert: nil}
+  def get_peer_data(payload) do
+    Map.fetch!(payload, :peer_data)
   end
 
   def get_http_protocol(payload) do

--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -160,6 +160,15 @@ defmodule Plug.Test do
   end
 
   @doc """
+  Puts the peer data.
+  """
+  def put_peer_data(conn, peer_data) do
+    update_in(conn.adapter, fn {adapter, payload} ->
+      {adapter, Map.put(payload, :peer_data, peer_data)}
+    end)
+  end
+
+  @doc """
   Puts a request cookie.
   """
   @spec put_req_cookie(Conn.t(), binary, binary) :: Conn.t()

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -117,4 +117,21 @@ defmodule Plug.Adapters.Test.ConnTest do
     child_conn = Plug.Adapters.Test.Conn.conn(conn_with_remote_ip, :get, "/", foo: "bar")
     assert child_conn.remote_ip == {151, 236, 219, 228}
   end
+
+  test "use custom peer data" do
+    certificate =
+      Path.expand("../../../fixtures/ssl/client.cer", __DIR__)
+      |> File.read!()
+
+    [{:Certificate, certificate, _}] = :public_key.pem_decode(certificate)
+
+    peer_data = %{address: {127, 0, 0, 1}, port: 111_317, ssl_cert: certificate}
+
+    conn =
+      conn(:get, "/")
+      |> put_peer_data(peer_data)
+
+    new_peer_data = Plug.Conn.get_peer_data(conn)
+    assert peer_data == new_peer_data
+  end
 end


### PR DESCRIPTION
There is currently no way to set the peer data in test. This PR adds `put_peer_data/2` to `Plug.Test`