### PR TITLE
Typespec for Plug.Crypto.secure_compare/2

### DIFF
--- a/lib/plug/crypto.ex
+++ b/lib/plug/crypto.ex
@@ -111,6 +111,7 @@ defmodule Plug.Crypto do
 
   See: http://codahale.com/a-lesson-in-timing-attacks/
   """
+  @spec secure_compare(binary(), binary()) :: boolean()
   def secure_compare(left, right) do
     if byte_size(left) == byte_size(right) do
       secure_compare(left, right, 0) == 0


### PR DESCRIPTION
It was unclear in my editor what this function would return, so I added
a typespec so it would be clearer for future users.