### PR TITLE
Improve error message when returning non-conn

### DIFF
--- a/lib/plug/builder.ex
+++ b/lib/plug/builder.ex
@@ -343,7 +343,7 @@ defmodule Plug.Builder do
             unquote(acc)
 
           other ->
-            raise unquote(error_message <> ", got: #{inspect(other)}")
+            raise unquote(error_message) <> ", got: #{inspect(other)}"
         end
       end
 

--- a/lib/plug/builder.ex
+++ b/lib/plug/builder.ex
@@ -342,8 +342,8 @@ defmodule Plug.Builder do
           %Plug.Conn{} = conn ->
             unquote(acc)
 
-          _ ->
-            raise unquote(error_message)
+          other ->
+            raise unquote(error_message <> ", got: #{inspect(other)}")
         end
       end
 


### PR DESCRIPTION
```
(RuntimeError) expected action/2 to return a Plug.Conn, all plugs must receive a connection (conn) and return a connection
```
Does not tell what **is** really happening