### PR TITLE
add to_string impl for Plug.Upload

### DIFF
--- a/lib/plug/upload.ex
+++ b/lib/plug/upload.ex
@@ -187,3 +187,9 @@ defmodule Plug.Upload do
     :ok
   end
 end
+
+defimpl String.Chars, for: Plug.Upload do
+  def to_string(%{path: path, filename: filename}) do
+    Path.join(path, filename)
+  end
+end

--- a/test/plug/upload_test.exs
+++ b/test/plug/upload_test.exs
@@ -30,4 +30,8 @@ defmodule Plug.UploadTest do
     :ok = Plug.Upload.terminate(:shutdown, [])
     refute File.exists?(path)
   end
+
+  test "get file path with to_string" do
+    assert "PATH/FILENAME" = to_string(%Plug.Upload{path: "PATH", filename: "FILENAME"})
+  end
 end


### PR DESCRIPTION
when I get a `File.Upload` variable `f`, I feel confused whether the path is `f.path` or `Path.join(f.path, f.filename)`.
I think it's a better way to get it by `to_string(f)`, just like get url by `URI` struct.