### PR TITLE
Update Plug.RequestId docs

### DIFF
--- a/lib/plug/request_id.ex
+++ b/lib/plug/request_id.ex
@@ -1,7 +1,8 @@
 defmodule Plug.RequestId do
   @moduledoc """
-  A plug for generating a unique request id for each request. A generated
-  request id will in the format "uq8hs30oafhj5vve8ji5pmp7mtopc08f".
+  A plug for generating a unique request id for each request. 
+  
+  The generated request id will be in the format "uq8hs30oafhj5vve8ji5pmp7mtopc08f".
 
   If a request id already exists as the "x-request-id" HTTP request header,
   then that value will be used assuming it is between 20 and 200 characters.


### PR DESCRIPTION
A minor change I spotted while reading the documentation of `Plug.RequestId`.