### PR TITLE
Replace status code 451 in the tests and docs with a made up one

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,7 +3,7 @@ use Mix.Config
 if Mix.env() == :test do
   config :plug, :statuses, %{
     418 => "Totally not a teapot",
-    451 => "Unavailable For Legal Reasons"
+    998 => "Not An RFC Status Code"
   }
 end
 

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -94,12 +94,12 @@ defmodule Plug.Conn do
   not directly specified by Plug or its adapters. Adding or overriding a status
   code is done through the Mix configuration of the `:plug` application. For
   example, to override the existing 404 reason phrase for the 404 status code
-  ("Not Found" by default) and add a new 451 status code, the following config
+  ("Not Found" by default) and add a new 998 status code, the following config
   can be specified:
 
       config :plug, :statuses, %{
         404 => "Actually This Was Found",
-        451 => "Unavailable For Legal Reasons"
+        998 => "Not An RFC Status Code"
       }
 
   As this configuration is Plug specific, Plug will need to be recompiled for
@@ -115,7 +115,7 @@ defmodule Plug.Conn do
 
       put_status(conn, :not_found)                     # 404
       put_status(conn, :actually_this_was_found)       # 404
-      put_status(conn, :unavailable_for_legal_reasons) # 451
+      put_status(conn, :not_an_rfc_status_code)        # 998
 
   Even though 404 has been overridden, the `:not_found` atom can still be used
   to set the status to 404 as well as the new atom `:actually_this_was_found`

--- a/lib/plug/conn/status.ex
+++ b/lib/plug/conn/status.ex
@@ -158,18 +158,18 @@ defmodule Plug.Conn.Status do
     under the :statuses key (which contains a map of status codes as keys and
     reason phrases as values). For example:
 
-        config :plug, :statuses, %{451 => "Unavailable For Legal Reasons"}
+        config :plug, :statuses, %{998 => "Not An RFC Status Code"}
 
     After defining the config for custom statuses, Plug must be recompiled for
     the changes to take place using:
 
         MIX_ENV=dev mix deps.clean plug --build
 
-    Doing this will allow the use of the integer status code 451 as
+    Doing this will allow the use of the integer status code 998 as
     well as the atom :unavailable_for_legal_reasons in many Plug functions.
     For example:
 
-        put_status(conn, :unavailable_for_legal_reasons)
+        put_status(conn, :not_an_rfc_status_code)
     """
   end
 end

--- a/test/plug/adapters/cowboy/conn_test.exs
+++ b/test/plug/adapters/cowboy/conn_test.exs
@@ -137,8 +137,8 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
     send_resp(conn, 418, "")
   end
 
-  def send_451(conn) do
-    send_resp(conn, 451, "")
+  def send_998(conn) do
+    send_resp(conn, 998, "")
   end
 
   def send_500(conn) do
@@ -160,9 +160,9 @@ defmodule Plug.Adapters.Cowboy.ConnTest do
   end
 
   test "allows customized statuses based on config" do
-    assert {451, _headers, ""} = request(:get, "/send_451")
-    {:ok, ref} = :hackney.get("http://127.0.0.1:8001/send_451", [], "", async: :once)
-    assert_receive({:hackney_response, ^ref, {:status, 451, "Unavailable For Legal Reasons"}})
+    assert {998, _headers, ""} = request(:get, "/send_998")
+    {:ok, ref} = :hackney.get("http://127.0.0.1:8001/send_998", [], "", async: :once)
+    assert_receive({:hackney_response, ^ref, {:status, 998, "Not An RFC Status Code"}})
     :hackney.close(ref)
   end
 

--- a/test/plug/adapters/cowboy2/conn_test.exs
+++ b/test/plug/adapters/cowboy2/conn_test.exs
@@ -153,8 +153,8 @@ defmodule Plug.Adapters.Cowboy2.ConnTest do
     send_resp(conn, 418, "")
   end
 
-  def send_451(conn) do
-    send_resp(conn, 451, "")
+  def send_998(conn) do
+    send_resp(conn, 998, "")
   end
 
   def send_500(conn) do
@@ -176,9 +176,9 @@ defmodule Plug.Adapters.Cowboy2.ConnTest do
   end
 
   test "allows customized statuses based on config" do
-    assert {451, _headers, ""} = request(:get, "/send_451")
-    {:ok, ref} = :hackney.get("http://127.0.0.1:8003/send_451", [], "", async: :once)
-    assert_receive({:hackney_response, ^ref, {:status, 451, "Unavailable For Legal Reasons"}})
+    assert {998, _headers, ""} = request(:get, "/send_998")
+    {:ok, ref} = :hackney.get("http://127.0.0.1:8003/send_998", [], "", async: :once)
+    assert_receive({:hackney_response, ^ref, {:status, 998, "Not An RFC Status Code"}})
     :hackney.close(ref)
   end
 

--- a/test/plug/conn/status_test.exs
+++ b/test/plug/conn/status_test.exs
@@ -10,7 +10,7 @@ defmodule Plug.Conn.StatusTest do
   end
 
   test "code for custom status return the numeric code" do
-    assert Status.code(:unavailable_for_legal_reasons) == 451
+    assert Status.code(:not_an_rfc_status_code) == 998
   end
 
   test "code with both a built_in and custom code return the numeric code" do
@@ -25,7 +25,7 @@ defmodule Plug.Conn.StatusTest do
   end
 
   test "reason_atom returns the atom for custom statuses" do
-    assert Status.reason_atom(451) == :unavailable_for_legal_reasons
+    assert Status.reason_atom(998) == :not_an_rfc_status_code
   end
 
   test "reason_atom with both a built_in and custom status always returns the custom atom" do
@@ -45,7 +45,7 @@ defmodule Plug.Conn.StatusTest do
   end
 
   test "reason_phrase for custom status return the phrase" do
-    assert Status.reason_phrase(451) == "Unavailable For Legal Reasons"
+    assert Status.reason_phrase(998) == "Not An RFC Status Code"
   end
 
   test "reason_phrase with both a built_in and custom status always returns the custom phrase" do


### PR DESCRIPTION
In commit 04ad2473060315c300c0360d1ef31e0fabf42265 the 451 status code
was added. This negates the value of some of the tests around adding a
new status code, along with the documentation. Instead of using 451, a
made up status code ("998 Not An RFC Status Code") is now used.