### PR TITLE
Fix Ranch 1.6.2 childspecs #771

### DIFF
--- a/lib/plug/adapters/cowboy2.ex
+++ b/lib/plug/adapters/cowboy2.ex
@@ -162,7 +162,6 @@ defmodule Plug.Adapters.Cowboy2 do
           {:ranch_ssl, :cowboy_tls, transport_opts}
       end
 
-    num_acceptors = Keyword.get(transport_opts, :num_acceptors, 100)
 
     %{
       id: {:ranch_listener_sup, ref},
@@ -170,7 +169,6 @@ defmodule Plug.Adapters.Cowboy2 do
         {:ranch_listener_sup, :start_link,
          [
            ref,
-           num_acceptors,
            ranch_module,
            transport_opts,
            cowboy_protocol,

--- a/test/plug/adapters/cowboy2_test.exs
+++ b/test/plug/adapters/cowboy2_test.exs
@@ -40,7 +40,6 @@ defmodule Plug.Adapters.Cowboy2Test do
 
       assert [
                Plug.Adapters.Cowboy2Test.HTTPS,
-               100,
                :ranch_ssl,
                transport_opts,
                :cowboy_tls,
@@ -49,6 +48,7 @@ defmodule Plug.Adapters.Cowboy2Test do
 
       assert Keyword.get(transport_opts, :alpn_preferred_protocols) == ["h2", "http/1.1"]
       assert Keyword.get(transport_opts, :next_protocols_advertised) == ["h2", "http/1.1"]
+      assert Keyword.get(transport_opts, :num_acceptors) == 100
     end
   end
 


### PR DESCRIPTION
Fix incompatible code with ranch 1.6.2, `:ranch_listener_sup.start_link/6` is now `:ranch_listener_sup.start_link/5.`