### PR TITLE
Tweaks to the README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Access "http://localhost:4000/" and we are done! For now, we have directly start
 
 You can use plug in your projects in two steps:
 
-1. Add plug and your webserver of choice (currently cowboy) to your `mix.exs` dependencies:
+1. Add plug and your webserver of choice (currently [Cowboy](https://github.com/ninenines/cowboy)) to your `mix.exs` dependencies:
 
     ```elixir
     def deps do
@@ -89,7 +89,10 @@ def hello_world_plug(conn, _opts) do
 end
 ```
 
-A module plug implements an `init/1` function to initialize the options and a `call/2` function which receives the connection and initialized options and returns the connection:
+A module plug implements two functions:
+
+1. An `init/1` function that initializes and returns the plug options.
+2. A `call/2` function which receives the connection and the value returned by `init/1`, and returns the connection:
 
 ```elixir
 defmodule MyPlug do
@@ -165,17 +168,19 @@ On a production system, you likely want to start your Plug pipeline under your a
 $ mix new my_app --sup
 ```
 
-and then update `lib/my_app.ex` as follows:
+and then update `lib/my_app/application.ex` as follows:
 
 ```elixir
 defmodule MyApp do
-  use Application
-
   # See https://hexdocs.pm/elixir/Application.html
   # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
   def start(_type, _args) do
+    # List all child processes to be supervised
     children = [
-      # Define workers and child supervisors to be supervised
       Plug.Adapters.Cowboy2.child_spec(scheme: :http, plug: MyRouter, options: [port: 4001])
     ]
 
@@ -220,11 +225,11 @@ This project aims to ship with different plugs that can be re-used across applic
   * `Plug.CSRFProtection` - adds Cross-Site Request Forgery protection to your application. Typically required if you are using `Plug.Session`;
   * `Plug.Head` - converts HEAD requests to GET requests;
   * `Plug.Logger` - logs requests;
-  * `Plug.MethodOverride` - overrides a request method with one specified in headers;
+  * `Plug.MethodOverride` - overrides a request method with one specified in the request parameters;
   * `Plug.Parsers` - responsible for parsing the request body given its content-type;
   * `Plug.RequestId` - sets up a request ID to be used in logs;
   * `Plug.Session` - handles session management and storage;
-  * `Plug.SSL` - enforce requests through SSL;
+  * `Plug.SSL` - enforces requests through SSL;
   * `Plug.Static` - serves static files;
 
 You can go into more details about each of them [in our docs](http://hexdocs.pm/plug/).

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ On a production system, you likely want to start your Plug pipeline under your a
 $ mix new my_app --sup
 ```
 
-and then update your application file (for example, `lib/my_app/application.ex`) as follows:
+and then update `lib/my_app/application.ex` as follows:
 
 ```elixir
 defmodule MyApp do

--- a/README.md
+++ b/README.md
@@ -89,10 +89,7 @@ def hello_world_plug(conn, _opts) do
 end
 ```
 
-A module plug implements two functions:
-
-1. An `init/1` function that initializes and returns the plug options.
-2. A `call/2` function which receives the connection and the value returned by `init/1`, and returns the connection:
+A module plug implements an `init/1` function to initialize the options and a `call/2` function which receives the connection and initialized options and returns the connection:
 
 ```elixir
 defmodule MyPlug do

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Access "http://localhost:4000/" and we are done! For now, we have directly start
 
 You can use plug in your projects in two steps:
 
-1. Add plug and your webserver of choice (currently [Cowboy](https://github.com/ninenines/cowboy)) to your `mix.exs` dependencies:
+1. Add plug and your webserver of choice (currently [Cowboy][cowboy]) to your `mix.exs` dependencies:
 
     ```elixir
     def deps do
@@ -168,7 +168,7 @@ On a production system, you likely want to start your Plug pipeline under your a
 $ mix new my_app --sup
 ```
 
-and then update `lib/my_app/application.ex` as follows:
+and then update your application file (for example, `lib/my_app/application.ex`) as follows:
 
 ```elixir
 defmodule MyApp do
@@ -265,3 +265,4 @@ Check LICENSE file for more information.
   [writing-docs]: https://hexdocs.pm/elixir/writing-documentation.html
   [IRC]: https://webchat.freenode.net/?channels=#elixir-lang
   [freenode]: https://freenode.net/
+  [cowboy]: https://github.com/ninenines/cowboy


### PR DESCRIPTION
Hey! Just a few tweaks:

* "Cowboy" has an uppercase "C", revised that and linked to its GitHub repo (the home page of 99s does not seem to have a dedicated URL, all projects have selectors in the nav bar.)
* The description of `call/2` makes explicit that the options received are whatever `init/1` returned.
* With that, the sentence was getting too long, the patch splits the explanation in two parts.
* Updates the source code of the generated sample application using 1.8.0-dev.
* `Plug.MethodOverride` checks the request parameters rather than the headers.
* Use the 3rd person in `Plug.SSL` for coherence with the rest.