### PR TITLE
Remove stacktraces from the warning when plug_cowboy is missing

### DIFF
--- a/lib/plug/adapters/cowboy.ex
+++ b/lib/plug/adapters/cowboy.ex
@@ -41,7 +41,7 @@ defmodule Plug.Adapters.Cowboy do
   end
 
   defp warn_and_raise() do
-    IO.warn("""
+    error = """
     please add the following dependency to your mix.exs:
 
         {:plug_cowboy, "~> 1.0"}
@@ -49,8 +49,9 @@ defmodule Plug.Adapters.Cowboy do
     This dependency is required by Plug.Adapters.Cowboy
     which you may be using directly or indirectly.
     Note you no longer need to depend on :cowboy directly.
-    """)
+    """
 
-    raise "plug_cowboy dependency missing"
+    IO.warn(error, [])
+    :erlang.raise(:exit, "plug_cowboy dependency missing", [])
   end
 end

--- a/lib/plug/adapters/cowboy2.ex
+++ b/lib/plug/adapters/cowboy2.ex
@@ -39,7 +39,7 @@ defmodule Plug.Adapters.Cowboy2 do
   end
 
   defp warn_and_raise() do
-    IO.warn("""
+    error = """
     please add the following dependency to your mix.exs:
 
         {:plug_cowboy, "~> 2.0"}
@@ -47,9 +47,10 @@ defmodule Plug.Adapters.Cowboy2 do
     This dependency is required by Plug.Adapters.Cowboy2
     which you may be using directly or indirectly.
     Note you no longer need to depend on :cowboy directly.
-    """)
+    """
 
-    raise "plug_cowboy dependency missing"
+    IO.warn(error, [])
+    :erlang.raise(:exit, "plug_cowboy dependency missing", [])
   end
 
   defp plug_cowboy_deprecation_warning() do

--- a/test/plug/adapters/cowboy2_test.exs
+++ b/test/plug/adapters/cowboy2_test.exs
@@ -66,9 +66,9 @@ defmodule Plug.Adapters.Cowboy2Test do
 
     output =
       capture_io(:stderr, fn ->
-        assert_raise(RuntimeError, @raise_message, fn ->
-          fun.()
-        end)
+        Process.flag(:trap_exit, true)
+        pid = spawn_link(fun)
+        assert_receive({:EXIT, ^pid, @raise_message})
       end)
 
     assert output =~ @missing_warning

--- a/test/plug/adapters/cowboy_test.exs
+++ b/test/plug/adapters/cowboy_test.exs
@@ -68,9 +68,9 @@ defmodule Plug.Adapters.CowboyTest do
 
     output =
       capture_io(:stderr, fn ->
-        assert_raise(RuntimeError, @raise_message, fn ->
-          fun.()
-        end)
+        Process.flag(:trap_exit, true)
+        pid = spawn_link(fun)
+        assert_receive({:EXIT, ^pid, @raise_message})
       end)
 
     assert output =~ @missing_warning


### PR DESCRIPTION
Previously, the `IO.warn` would include a stacktrace, as well as any
logs and the exit. The stacktraces have been removed as the warning
includes sufficient information to resolve the issue, and the
stacktraces would push this further up in the output from the terminal.