### PR TITLE
Clarify behavior around parsing "scalar" JSON documents

### DIFF
--- a/lib/plug/parsers/json.ex
+++ b/lib/plug/parsers/json.ex
@@ -2,8 +2,8 @@ defmodule Plug.Parsers.JSON do
   @moduledoc """
   Parses JSON request body.
 
-  JSON arrays are parsed into a `"_json"` key to allow
-  proper param merging.
+  JSON documents that aren't maps (arrays, strings, numbers, etc) are parsed
+  into a `"_json"` key to allow proper param merging.
 
   An empty request body is parsed as an empty map.
 

--- a/test/plug/parsers/json_test.exs
+++ b/test/plug/parsers/json_test.exs
@@ -19,6 +19,22 @@ defmodule Plug.Parsers.JSONTest do
       %{"query" => "fooBAZ"}
     end
 
+    def decode!(~s("str")) do
+      "str"
+    end
+
+    def decode!(~s(1)) do
+      1
+    end
+
+    def decode!(~s(false)) do
+      false
+    end
+
+    def decode!(~s(null)) do
+      nil
+    end
+
     def decode!(_) do
       raise "oops"
     end
@@ -63,9 +79,24 @@ defmodule Plug.Parsers.JSONTest do
     assert conn.params["_json"] == [1, 2, 3]
   end
 
-  test "handles empty body as blank map" do
-    conn = nil |> json_conn() |> parse()
-    assert conn.params == %{}
+  test "parses the request body when it is a scalar" do
+    conn = ~s("str") |> json_conn() |> parse()
+    assert conn.params["_json"] == "str"
+  end
+
+  test "parses the request body when it is a number" do
+    conn = ~s(1) |> json_conn() |> parse()
+    assert conn.params["_json"] == 1
+  end
+
+  test "parses the request body when it is a boolean" do
+    conn = ~s(false) |> json_conn() |> parse()
+    assert conn.params["_json"] == false
+  end
+
+  test "parses the request body when it is null" do
+    conn = ~s(null) |> json_conn() |> parse()
+    assert conn.params["_json"] == nil
   end
 
   test "parses json-parseable content types" do


### PR DESCRIPTION
This PR clarifies the behavior of `plug` around parsing non-map JSON documents. I encountered this inside `absinthe_plug` when it assumed that anything inside `_json` would be an array, when in fact it can be any number of things..

https://github.com/absinthe-graphql/absinthe_plug/pull/186