### PR TITLE
Update installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,25 +42,15 @@ Access "http://localhost:4000/" and we are done! For now, we have directly start
 
 ## Installation
 
-You can use plug in your projects in two steps:
+You can use plug in your projects adding the plug adapter to your `mix.exs` dependencies:
 
-1. Add the plug adapter of your choice (currently [Cowboy][cowboy]) to your `mix.exs` dependencies:
-
-    ```elixir
-    def deps do
-      [
-        {:plug_cowboy, "~> 2.0"}
-      ]
-    end
-    ```
-
-2. List both `:cowboy` and `:plug` as your application dependencies:
-
-    ```elixir
-    def application do
-      [applications: [:plug_cowboy]]
-    end
-    ```
+```elixir
+def deps do
+  [
+    {:plug_cowboy, "~> 2.0"}
+  ]
+end
+```
 
 ## Supported Versions
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Access "http://localhost:4000/" and we are done! For now, we have directly start
 
 ## Installation
 
-You can use plug in your projects adding the plug adapter to your `mix.exs` dependencies:
+In order to use Plug, you need a webserver and its bindings for Plug. For example, to use the Cowboy webserver with Plug, just add the `plug_cowboy` dependency to your `mix.exs`:
 
 ```elixir
 def deps do


### PR DESCRIPTION
This PR updates the instruction to use `plug_cowboy` instead of `plug` and `cowboy` applications.

The two steps were combined to one, as per since elixir 1.4 the application inference was added [Elixir v1.4 released](https://elixir-lang.org/blog/2017/01/05/elixir-v1-4-0-released/).