### PR TITLE
Add ability to disable request id validation in Plug.RequestId

### DIFF
--- a/test/plug/request_id_test.exs
+++ b/test/plug/request_id_test.exs
@@ -29,6 +29,20 @@ defmodule Plug.RequestIdTest do
     assert res_request_id == meta_request_id
   end
 
+  test "uses short existing id if validation is disabled" do
+    request_id = "tooshort"
+
+    conn =
+      conn(:get, "/")
+      |> put_req_header("x-request-id", request_id)
+      |> call([validate: false])
+
+    [res_request_id] = get_resp_header(conn, "x-request-id")
+    meta_request_id = Logger.metadata()[:request_id]
+    assert res_request_id == request_id
+    assert res_request_id == meta_request_id
+  end
+
   test "uses existing request id" do
     request_id = "existingidthatislongenough"
 


### PR DESCRIPTION
If `validate` set to `false` the plug will ignore the length of request id.

In some cases, it is fine to have id shorter than 20 characters.