### PR TITLE
Add Logger.metadata for execution time and status

### DIFF
--- a/lib/plug/logger.ex
+++ b/lib/plug/logger.ex
@@ -35,14 +35,18 @@ defmodule Plug.Logger do
       diff = System.convert_time_unit(stop - start, :native, :microsecond)
       status = Integer.to_string(conn.status)
 
-      Logger.metadata(
+      metadata = [
         status: status,
         execution_time: diff
-      )
+      ]
 
-      Logger.log(level, fn ->
-        [connection_type(conn), ?\s, status, " in ", formatted_diff(diff)]
-      end)
+      Logger.log(
+        level,
+        fn ->
+          [connection_type(conn), ?\s, status, " in ", formatted_diff(diff)]
+        end,
+        metadata
+      )
 
       conn
     end)

--- a/lib/plug/logger.ex
+++ b/lib/plug/logger.ex
@@ -31,11 +31,16 @@ defmodule Plug.Logger do
     start = System.monotonic_time()
 
     Conn.register_before_send(conn, fn conn ->
-      Logger.log(level, fn ->
-        stop = System.monotonic_time()
-        diff = System.convert_time_unit(stop - start, :native, :microsecond)
-        status = Integer.to_string(conn.status)
+      stop = System.monotonic_time()
+      diff = System.convert_time_unit(stop - start, :native, :microsecond)
+      status = Integer.to_string(conn.status)
 
+      Logger.metadata(
+        status: status,
+        execution_time: diff
+      )
+
+      Logger.log(level, fn ->
         [connection_type(conn), ?\s, status, " in ", formatted_diff(diff)]
       end)
 


### PR DESCRIPTION
When logging requests in Plug it would be awesome for our Kibana dashboard to have the metadata about the status and execution_time. If we want to have the average response time right now, we have to parse it from the actual message, with this metadata we don't.
