### PR TITLE
Do not disable client renegotiation

### DIFF
--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -175,8 +175,7 @@ defmodule Plug.SSL do
   recommendations: https://wiki.mozilla.org/Security/Server_Side_TLS#Cipher_names_correspondence_table
 
   In addition to selecting a group of ciphers, selecting a cipher suite will also
-  disable client renegotiation and force the client to honor the server specified
-  cipher order.
+  force the client to honor the server specified cipher order.
 
   Any of those choices can be disabled on a per choice basis by specifying the
   equivalent SSL option alongside the cipher suite.
@@ -315,7 +314,6 @@ defmodule Plug.SSL do
   defp set_managed_tls_defaults(options) do
     options
     |> Keyword.put_new(:honor_cipher_order, true)
-    |> Keyword.put_new(:client_renegotiation, false)
     |> Keyword.put_new(:eccs, @eccs)
   end
 

--- a/test/plug/ssl_test.exs
+++ b/test/plug/ssl_test.exs
@@ -21,7 +21,6 @@ defmodule Plug.SSLTest do
       assert {:ok, opts} = configure(key: "abcdef", cert: "ghijkl", cipher_suite: :strong)
       assert opts[:cipher_suite] == nil
       assert opts[:honor_cipher_order] == true
-      assert opts[:client_renegotiation] == false
       assert opts[:eccs] == [:secp256r1, :secp384r1, :secp521r1]
       assert opts[:versions] == [:"tlsv1.2"]
 
@@ -39,7 +38,6 @@ defmodule Plug.SSLTest do
       assert {:ok, opts} = configure(key: "abcdef", cert: "ghijkl", cipher_suite: :compatible)
       assert opts[:cipher_suite] == nil
       assert opts[:honor_cipher_order] == true
-      assert opts[:client_renegotiation] == false
       assert opts[:eccs] == [:secp256r1, :secp384r1, :secp521r1]
       assert opts[:versions] == [:"tlsv1.2", :"tlsv1.1", :tlsv1]
 


### PR DESCRIPTION
Erlang/OTP already rate-limits client renegotiation requests to
mitigate any DoS impact. Disabling client renegotiation altogether
can cause long-lived connections to fail eventually due to
sequence numbers wrapping.