### PR TITLE
Fix malformed boundaries multipart

### DIFF
--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -178,6 +178,32 @@ defmodule Plug.ParsersTest do
     assert params == %{}
   end
 
+  test "parses malformed multipart body" do
+    %{params: params} =
+      conn(:post, "/", "{}")
+      |> put_req_header("content-type", "multipart/form-data")
+      |> put_req_header("boundary", "xYzZY")
+      |> parse()
+
+    assert params == %{}
+
+    %{params: params} =
+      conn(:post, "/", "{")
+      |> put_req_header("content-type", "multipart/form-data")
+      |> put_req_header("boundary", "xYzZY")
+      |> parse()
+
+    assert params == %{}
+
+    %{params: params} =
+      conn(:post, "/", nil)
+      |> put_req_header("content-type", "multipart/form-data")
+      |> put_req_header("boundary", "xYzZY")
+      |> parse()
+
+    assert params == %{}
+  end
+
   test "parses with custom body reader" do
     conn = conn(:post, "/?query=elixir", "body=foo")
 

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -238,6 +238,16 @@ defmodule Plug.ParsersTest do
     end
   end
 
+  test "raises on invalid url encoded for multipart" do
+    message = "invalid UTF-8 on urlencoded body, got byte 139"
+
+    assert_raise Plug.Parsers.BadEncodingError, message, fn ->
+      conn(:post, "/", "wrong data" <> <<139>>)
+      |> put_req_header("content-type", "multipart/form-data")
+      |> parse()
+    end
+  end
+
   test "raises on too large bodies with root option" do
     exception =
       assert_raise Plug.Parsers.RequestTooLargeError, ~r/the request is too large/, fn ->


### PR DESCRIPTION
Hi there,

I created some tests in hopes to get a better understanding of malformed boundary requests. These are hitting my api, but I cannot catch them before they hit my Plug in my Router.

I've tried a custom [error handler](https://github.com/elixir-plug/plug/blob/master/lib/plug/error_handler.ex), but the request itself fails on the Plug, before it even reaches the custom error handler. 

I am unsure the best way to approach this using Plug, and thought it may do some good with my test cases below to illustrate the problem I am having.

In a regular Phoenix app, one can run:
```
curl \
    -X POST \
    -H "Content-Type: multipart/form-data; boundary=xYzZY" \
    -H "Host: localhost" \
    -H "Total-Route-Time: 0" \
    "http://localhost:4000/api/post_route"
```

to recreate this error