### PR TITLE
Document breaking changes in 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
   * [Plug.SSL] Don't redirect excluded hosts on Plug.SSL
 
+### Breaking Changes
+
+You may need to add `:plug_cowboy` to your deps to use this version
+
 ## v1.6
 
 See [CHANGELOG in the v1.6 branch](https://github.com/elixir-plug/plug/blob/v1.6/CHANGELOG.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Breaking Changes
 
-You may need to add `:plug_cowboy` to your deps to use this version
+  * [Plug] Applications may need to add `:plug_cowboy` to your deps to use this version
 
 ## v1.6
 


### PR DESCRIPTION
After upgrading from plug 1.6.4 to 1.7.1 I unexpectedly had issues starting my server which caught me off guard because there were no breaking changes listed in the plug changelog and I hadn't updated anything else.

Semi-related Phoenix issue:
https://github.com/phoenixframework/phoenix/issues/3119