### PR TITLE
Support UTF-8 filename encoding in multipart parser (RFC2231)

### DIFF
--- a/lib/plug/parsers/multipart.ex
+++ b/lib/plug/parsers/multipart.ex
@@ -172,7 +172,21 @@ defmodule Plug.Parsers.MULTIPART do
         {:file, name, path, upload}
 
       :error ->
-        {:binary, name}
+        case Map.fetch(params, "filename*") do
+          {:ok, ""} ->
+            :skip
+
+          {:ok, "utf-8''" <> filename} ->
+            filename = URI.decode(filename)
+            path = Plug.Upload.random_file!("multipart")
+            content_type = get_header(headers, "content-type")
+            upload = %Plug.Upload{filename: filename, path: path, content_type: content_type}
+            {:file, name, path, upload}
+
+          :error ->
+            {:binary, name}
+        end
+
     end
   end
 

--- a/lib/plug/parsers/multipart.ex
+++ b/lib/plug/parsers/multipart.ex
@@ -178,6 +178,7 @@ defmodule Plug.Parsers.MULTIPART do
 
           {:ok, "utf-8''" <> filename} ->
             filename = URI.decode(filename)
+            Plug.Conn.Utils.validate_utf8!(filename, Plug.Parsers.BadEncodingError, "multipart filename")
             path = Plug.Upload.random_file!("multipart")
             content_type = get_header(headers, "content-type")
             upload = %Plug.Upload{filename: filename, path: path, content_type: content_type}

--- a/lib/plug/parsers/multipart.ex
+++ b/lib/plug/parsers/multipart.ex
@@ -178,7 +178,13 @@ defmodule Plug.Parsers.MULTIPART do
 
           {:ok, "utf-8''" <> filename} ->
             filename = URI.decode(filename)
-            Plug.Conn.Utils.validate_utf8!(filename, Plug.Parsers.BadEncodingError, "multipart filename")
+
+            Plug.Conn.Utils.validate_utf8!(
+              filename,
+              Plug.Parsers.BadEncodingError,
+              "multipart filename"
+            )
+
             path = Plug.Upload.random_file!("multipart")
             content_type = get_header(headers, "content-type")
             upload = %Plug.Upload{filename: filename, path: path, content_type: content_type}
@@ -187,7 +193,6 @@ defmodule Plug.Parsers.MULTIPART do
           :error ->
             {:binary, name}
         end
-
     end
   end
 

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -131,6 +131,13 @@ defmodule Plug.ParsersTest do
 
     \r
     ------w58EW1cEpjzydSCq\r
+    Content-Disposition: form-data; name=\"doc\"; filename*=\"utf-8''%C5%BC%C3%B3%C5%82%C4%87.txt\"\r
+    Content-Type: text/plain\r
+    \r
+    hello
+
+    \r
+    ------w58EW1cEpjzydSCq\r
     Content-Disposition: form-data\r
     \r
     skipped\r
@@ -167,6 +174,11 @@ defmodule Plug.ParsersTest do
     assert File.read!(file.path) == "hello\n\n"
     assert file.content_type == "text/plain"
     assert file.filename == "foo.txt"
+
+    assert %Plug.Upload{} = file = params["doc"]
+    assert File.read!(file.path) == "hello\n\n"
+    assert file.content_type == "text/plain"
+    assert file.filename == "żółć.txt"
   end
 
   test "parses empty multipart body" do


### PR DESCRIPTION
As discussed in #793 this one addresses subset of cases covered by RFC2231 - applies to UTF-8 encoding only, and to multipart header values related to file uploads only.

This probably covers 80% of real world cases where non-ascii multi-part header encoding is used, so I believe it's already useful. I've been using this patch in production for 2 months now without problems.

Covering other encodings, and non-file upload headers could be implemented in a separate PR (if we think it's worth it), probably on `Plug.Conn.Utils.params` level.