### PR TITLE
Version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## v1.7.2 (2019-02-09)
+
 ## v1.7.1 (2018-10-24)
 
   * [Plug.Adapters.Cowboy] Less verbose output when plug_cowboy is missing

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.MixProject do
   use Mix.Project
 
-  @version "1.7.1"
+  @version "1.7.2"
   @description "A specification and conveniences for composable modules between web applications"
   @xref_exclude [Plug.Cowboy]
 


### PR DESCRIPTION
I saw a new 1.7.2 release on hex.pm. We may want to bump the version in mix.exs :)
1st commit does that, 2nd one adds section for 1.7.2 to changelog (I'm not yet familiar with all changes that went into 1.7.2 so didn't prepare a bullet point list for it, but I can give it a shot by re-wording commit messages).