### PR TITLE
allow multipart without requiring 'Content-Disposition' headers

### DIFF
--- a/lib/plug/parsers/multipart.ex
+++ b/lib/plug/parsers/multipart.ex
@@ -176,20 +176,17 @@ defmodule Plug.Parsers.MULTIPART do
   end
 
   defp multipart_type(headers, opts) do
-    case get_header(headers, "content-disposition") do
-      disposition when is_binary(disposition) ->
-        multipart_type_from_disposition(headers, disposition)
-
-      _ ->
-        multipart_type_from_unnamed(opts)
+    if disposition = get_header(headers, "content-disposition") do
+      multipart_type_from_disposition(headers, disposition)
+    else
+      multipart_type_from_unnamed(opts)
     end
   end
 
   defp multipart_type_from_unnamed(opts) do
-    with "" <> name when is_binary(name) <- Keyword.get(opts, :include_unnamed_parts_at, :skip) do
-      {:part, name <> "[]"}
-    else
-      _ -> :skip
+    case Keyword.fetch(opts, :include_unnamed_parts_at) do
+      {:ok, name} when is_binary(name) -> {:part, name <> "[]"}
+      :error -> :skip
     end
   end
 

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -158,6 +158,18 @@ defmodule Plug.ParsersTest do
     Content-Disposition: form-data; name=\"commit\"\r
     \r
     Create User\r
+    ------w58EW1cEpjzydSCq\r
+    Content-Type: application/json\r
+    \r
+    {"indisposed": "json"}\r
+    ------w58EW1cEpjzydSCq\r
+    Content-Type: application/octet-stream\r
+    X-My-Foo: bar\r
+    \r
+    foo\r
+    ------w58EW1cEpjzydSCq\r
+    \r
+    No content-type? No problem!\r
     ------w58EW1cEpjzydSCq--\r
     """
 
@@ -179,6 +191,14 @@ defmodule Plug.ParsersTest do
     assert File.read!(file.path) == "hello\n\n"
     assert file.content_type == "text/plain"
     assert file.filename == "żółć.txt"
+
+    assert [
+             %{body: "{\"indisposed\": \"json\"}"},
+             %{body: "foo", headers: [{_, _}, {_, _}] = part_headers},
+             %{body: "No content-type? No problem!"}
+           ] = params["_parts"]
+
+    assert %{"x-my-foo" => "bar"} = Enum.into(part_headers, %{})
   end
 
   test "parses empty multipart body" do


### PR DESCRIPTION
This is targeting [an issue I just ran into](https://github.com/elixir-plug/plug/issues/819) where the multipart parser is making Content-Disposition required to accept multipart requests, when I think Content-Disposition should be optional for multipart. (More/better context in that issue).

The current implementation wants a name for each part parameter, and expects to get it from the Content-Disposition header.

### Proposed change

The JSON body parser has the pattern where

- if you POST `{a: 1}`, then `body_params` will have `%{"a" => 1}`.
- if you POST `[{a: 1}]`, then `body_params` will have `%{"_json" => [%{"a" => 1}]}`

I was wondering if it'd work for the multipart parser to do something like that -- placing any unnamed, not-an-upload parts -- into a `"_parts" => [ part ]` parameter.

**This PR adds a body parameter to hold these 'unnamed body parts':**

    "_parts" => [
       %{body: "{}", headers: [{"content-type", "application/json"}]},
       %{body: "raw", headers: [{"content-type", "application/octet-stream"}]}
     ]

I see there's been discussion about doing more than this -- but I'm still hopeful, as it seems like I'm the only person to have this specific need so far. So maybe a PR that adds a new body param only in these specific circumstances would have a chance of working without breaking things.