### PR TITLE
fix prepend_resp_headers/2 example usage

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -796,7 +796,7 @@ defmodule Plug.Conn do
 
   ## Examples
 
-      Plug.Conn.prepend_resp_headers(conn, "content-type", "application/json")
+      Plug.Conn.prepend_resp_headers(conn, [{"content-type", "application/json"}])
 
   """
   @spec prepend_resp_headers(t, headers) :: t


### PR DESCRIPTION
The docs state `Plug.Conn.prepend_resp_headers(conn, "content-type", "application/json")` but this appears to be incorrectly attempting to call a non-existent `prepend_resp_headers/3` in fact it takes a headers list.

I've updated the docs example to reflect the reality of the situation.