### PR TITLE
Add a Plug.Telemetry for instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ This project aims to ship with different plugs that can be re-used across applic
   * `Plug.Session` - handles session management and storage;
   * `Plug.SSL` - enforces requests through SSL;
   * `Plug.Static` - serves static files;
+  * `Plug.Telemetry` - instruments the plug pipeline with `:telemetry` events;
 
 You can go into more details about each of them [in our docs](http://hexdocs.pm/plug/).
 

--- a/lib/plug/telemetry.ex
+++ b/lib/plug/telemetry.ex
@@ -1,6 +1,46 @@
 defmodule Plug.Telemetry do
   @moduledoc """
   A plug to instrument the pipeline with `:telemetry` events.
+
+  Currently the following events are emitted (event names assume that `:event_prefix` option is set
+  to `[:my, :plug]` - more on that in the paragraph below):
+    * `[:my, :plug, :call, :start]` - emitted right after this plug is invoked. There are no
+      measurements in this event, and the only metadata is the whole `Plug.Conn` under the `:conn`
+      key
+    * `[:my, :plug, :call, :stop]` - emitted right before the request is sent back. The event carries
+      a single measurement, `:duration`, which is the monotonic time difference between the stop
+      and start events. The duration is presented in the `:native` time unit (see docs for
+      `System.convert_time_unit/3` for more information). The same as for the start event, the only
+      metadata is the `Plug.Conn` struct under the `:conn` key.
+
+  The names of the events are based on the provided `event_prefix`: for the start event, the name is
+  `event_prefix ++ [:call, :start]`, and for the stop event: `event_prefix ++ [:call, :stop]`.
+  The event prefix is required, so that event consumers can differentiate between events emitted by
+  multiple instances of this plug.
+
+  Note that this plug measures only the time between its invocation and the rest of the plug pipeline -
+  this can be used to exclude some plugs from measurement.
+
+  ## Example
+
+      defmodule InstrumentedPlug do
+        use Plug.Router
+
+        plug :match
+
+        plug Plug.Telemetry, event_prefix: [:my, :plug]
+        plug Plug.Parsers, parsers: [:urlencoded, :multipart]
+
+        plug :dispatch
+
+        get "/" do
+          send_resp(conn, 200, "Hello, world!")
+        end
+      end
+
+  In this example, the stop event's `duration` includes the time it takes to parse the request,
+  dispatch it to the correct handler, and execute the handler. The events are not emitted for requests
+  not matching any handlers, since the plug is placed after the match plug.
   """
 
   @behaviour Plug

--- a/lib/plug/telemetry.ex
+++ b/lib/plug/telemetry.ex
@@ -1,0 +1,26 @@
+defmodule Plug.Telemetry do
+  @moduledoc """
+  A plug to instrument the pipeline with `:telemetry` events.
+  """
+
+  @behaviour Plug
+
+  @impl true
+  def init(_), do: []
+
+  @impl true
+  def call(conn, _opts) do
+    time = System.monotonic_time()
+    :telemetry.execute([:plug, :call, :start], %{}, %{conn: conn})
+
+    conn
+    |> Plug.Conn.put_private(:plug_telemetry_start_time, time)
+    |> Plug.Conn.register_before_send(&emit_stop_event/1)
+  end
+
+  defp emit_stop_event(conn) do
+    time = System.monotonic_time() - conn.private[:plug_telemetry_start_time]
+    :telemetry.execute([:plug, :call, :stop], %{time: time}, %{conn: conn, status: conn.status})
+    conn
+  end
+end

--- a/lib/plug/telemetry.ex
+++ b/lib/plug/telemetry.ex
@@ -19,8 +19,13 @@ defmodule Plug.Telemetry do
   end
 
   defp emit_stop_event(conn) do
-    time = System.monotonic_time() - conn.private[:plug_telemetry_start_time]
-    :telemetry.execute([:plug, :call, :stop], %{time: time}, %{conn: conn, status: conn.status})
+    duration = System.monotonic_time() - conn.private[:plug_telemetry_start_time]
+
+    :telemetry.execute([:plug, :call, :stop], %{duration: duration}, %{
+      conn: conn,
+      status: conn.status
+    })
+
     conn
   end
 end

--- a/lib/plug/telemetry.ex
+++ b/lib/plug/telemetry.ex
@@ -23,9 +23,9 @@ defmodule Plug.Telemetry do
       duration = System.monotonic_time() - start_time
 
       :telemetry.execute(stop_event, %{duration: duration}, %{
-        conn: conn,
-        status: conn.status
+        conn: conn
       })
+
       conn
     end)
   end
@@ -44,7 +44,8 @@ defmodule Plug.Telemetry do
     if is_list(event_prefix) && Enum.all?(event_prefix, &is_atom/1) do
       :ok
     else
-      raise ArgumentError, "expected :event_prefix to be a list of atoms, got: #{inspect(event_prefix)}"
+      raise ArgumentError,
+            "expected :event_prefix to be a list of atoms, got: #{inspect(event_prefix)}"
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -42,6 +42,7 @@ defmodule Plug.MixProject do
     [
       {:mime, "~> 1.0"},
       {:plug_crypto, "~> 1.0"},
+      {:telemetry, "~> 0.4.0", only: :test},
       {:ex_doc, "~> 0.19.1", only: :docs}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -17,4 +17,5 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.6.2", "6db93c78f411ee033dbb18ba8234c5574883acb9a75af0fb90a9b82ea46afa00", [:rebar3], [], "hexpm"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
 }

--- a/test/plug/telemetry_test.exs
+++ b/test/plug/telemetry_test.exs
@@ -43,13 +43,16 @@ defmodule Plug.TelemetryTest do
 
     assert_received {:event, [:pipeline, :call, :start], measurements, metadata}
     assert %{} == measurements
+    assert map_size(metadata) == 1
     assert %{conn: conn} = metadata
 
     assert_received {:event, [:pipeline, :call, :stop], measurements, metadata}
     assert %{duration: duration} = measurements
     assert is_integer(duration)
-    assert %{conn: conn, status: 200} = metadata
+    assert map_size(metadata) == 1
+    assert %{conn: conn} = metadata
     assert conn.state == :set
+    assert conn.status == 200
   end
 
   test "doesn't emit an event if the response is not sent", %{

--- a/test/plug/telemetry_test.exs
+++ b/test/plug/telemetry_test.exs
@@ -1,0 +1,61 @@
+defmodule Plug.TelemetryTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  defmodule MyPlug do
+    use Plug.Builder
+
+    plug Plug.Telemetry
+
+    plug :send_resp, 200
+
+    def send_resp(conn, status) do
+      Plug.Conn.send_resp(conn, status, "Response")
+    end
+  end
+
+  defmodule MyNoSendPlug do
+    use Plug.Builder
+
+    plug Plug.Telemetry
+  end
+
+  setup do
+    :telemetry.attach(:start, [:plug, :call, :start], fn _, measurements, metadata, _ ->
+      send(self(), {:event, :start, measurements, metadata})
+    end, nil)
+    :telemetry.attach(:stop, [:plug, :call, :stop], fn _, measurements, metadata, _ ->
+      send(self(), {:event, :stop, measurements, metadata})
+    end, nil)
+
+    on_exit(fn ->
+     :telemetry.detach(:start)
+     :telemetry.detach(:stop)
+    end)
+
+  end
+
+  test "emits an event before the pipeline and before sending the response" do
+    MyPlug.call(conn(:get, "/"), [])
+
+    assert_received {:event, :start, measurements, metadata}
+    assert %{} == measurements
+    assert %{conn: conn} = metadata
+
+    assert_received {:event, :stop, measurements, metadata}
+    assert %{time: time} = measurements
+    assert is_integer(time)
+    assert %{conn: conn, status: 200} = metadata
+    assert conn.state == :set
+  end
+
+  test "doesn't emit an event if the response is not sent" do
+    MyNoSendPlug.call(conn(:get, "/"), [])
+
+    assert_received {:event, :start, measurements, metadata}
+    assert %{} == measurements
+    assert %{conn: conn} = metadata
+
+    refute_received {:event, :stop, _, _}
+  end
+end

--- a/test/plug/telemetry_test.exs
+++ b/test/plug/telemetry_test.exs
@@ -58,13 +58,17 @@ defmodule Plug.TelemetryTest do
     MyPlug.call(conn(:get, "/"), [])
 
     assert_received {:event, [:pipeline, :call, :start], measurements, metadata}
-    assert %{} == measurements
+    assert map_size(measurements) == 1
+    assert %{time: time} = measurements
+    assert is_integer(time)
     assert map_size(metadata) == 1
     assert %{conn: conn} = metadata
 
     assert_received {:event, [:pipeline, :call, :stop], measurements, metadata}
-    assert %{duration: duration} = measurements
+    assert map_size(measurements) == 2
+    assert %{duration: duration, time: time} = measurements
     assert is_integer(duration)
+    assert is_integer(time)
     assert map_size(metadata) == 1
     assert %{conn: conn} = metadata
     assert conn.state == :set
@@ -80,10 +84,7 @@ defmodule Plug.TelemetryTest do
 
     MyNoSendPlug.call(conn(:get, "/"), [])
 
-    assert_received {:event, [:nosend, :pipeline, :call, :start], measurements, metadata}
-    assert %{} == measurements
-    assert %{conn: conn} = metadata
-
+    assert_received {:event, [:nosend, :pipeline, :call, :start], _, _}
     refute_received {:event, [:nosend, :pipeline, :call, :stop], _, _}
   end
 
@@ -110,10 +111,7 @@ defmodule Plug.TelemetryTest do
       MyCrashingPlug.call(conn(:get, "/"), [])
     end
 
-    assert_received {:event, [:crashing, :pipeline, :call, :start], measurements, metadata}
-    assert %{} == measurements
-    assert %{conn: conn} = metadata
-
+    assert_received {:event, [:crashing, :pipeline, :call, :start], _, _}
     refute_received {:event, [:crashing, :pipeline, :call, :stop], _, _}
   end
 

--- a/test/plug/telemetry_test.exs
+++ b/test/plug/telemetry_test.exs
@@ -5,7 +5,7 @@ defmodule Plug.TelemetryTest do
   defmodule MyPlug do
     use Plug.Builder
 
-    plug Plug.Telemetry
+    plug Plug.Telemetry, event_prefix: [:pipeline]
 
     plug :send_resp, 200
 
@@ -17,55 +17,77 @@ defmodule Plug.TelemetryTest do
   defmodule MyNoSendPlug do
     use Plug.Builder
 
-    plug Plug.Telemetry
+    plug Plug.Telemetry, event_prefix: [:nosend, :pipeline]
   end
 
   setup do
-    :telemetry.attach(
-      :start,
-      [:plug, :call, :start],
-      fn _, measurements, metadata, _ ->
-        send(self(), {:event, :start, measurements, metadata})
-      end,
-      nil
-    )
-
-    :telemetry.attach(
-      :stop,
-      [:plug, :call, :stop],
-      fn _, measurements, metadata, _ ->
-        send(self(), {:event, :stop, measurements, metadata})
-      end,
-      nil
-    )
+    start_handler_id = {:start, :rand.uniform(100)}
+    stop_handler_id = {:stop, :rand.uniform(100)}
 
     on_exit(fn ->
-      :telemetry.detach(:start)
-      :telemetry.detach(:stop)
+      :telemetry.detach(start_handler_id)
+      :telemetry.detach(stop_handler_id)
     end)
+
+    {:ok, start_handler: start_handler_id, stop_handler: stop_handler_id}
   end
 
-  test "emits an event before the pipeline and before sending the response" do
+  test "emits an event before the pipeline and before sending the response", %{
+    start_handler: start_handler,
+    stop_handler: stop_handler
+  } do
+    attach(start_handler, [:pipeline, :call, :start])
+    attach(stop_handler, [:pipeline, :call, :stop])
+
     MyPlug.call(conn(:get, "/"), [])
 
-    assert_received {:event, :start, measurements, metadata}
+    assert_received {:event, [:pipeline, :call, :start], measurements, metadata}
     assert %{} == measurements
     assert %{conn: conn} = metadata
 
-    assert_received {:event, :stop, measurements, metadata}
+    assert_received {:event, [:pipeline, :call, :stop], measurements, metadata}
     assert %{duration: duration} = measurements
     assert is_integer(duration)
     assert %{conn: conn, status: 200} = metadata
     assert conn.state == :set
   end
 
-  test "doesn't emit an event if the response is not sent" do
+  test "doesn't emit an event if the response is not sent", %{
+    start_handler: start_handler,
+    stop_handler: stop_handler
+  } do
+    attach(start_handler, [:nosend, :pipeline, :call, :start])
+    attach(stop_handler, [:nosend, :pipeline, :call, :stop])
+
     MyNoSendPlug.call(conn(:get, "/"), [])
 
-    assert_received {:event, :start, measurements, metadata}
+    assert_received {:event, [:nosend, :pipeline, :call, :start], measurements, metadata}
     assert %{} == measurements
     assert %{conn: conn} = metadata
 
-    refute_received {:event, :stop, _, _}
+    refute_received {:event, [:nosend, :pipeline, :call, :stop], _, _}
+  end
+
+  test "raises if event prefix is not provided" do
+    assert_raise ArgumentError, ~r/^:event_prefix is required$/, fn ->
+      Plug.Telemetry.init([])
+    end
+  end
+
+  test "raises if event prefix is not a list of atoms" do
+    assert_raise ArgumentError, ~r/^expected :event_prefix to be a list of atoms, got: 1$/, fn ->
+      Plug.Telemetry.init(event_prefix: 1)
+    end
+  end
+
+  defp attach(handler_id, event) do
+    :telemetry.attach(
+      handler_id,
+      event,
+      fn event, measurements, metadata, _ ->
+        send(self(), {:event, event, measurements, metadata})
+      end,
+      nil
+    )
   end
 end

--- a/test/plug/telemetry_test.exs
+++ b/test/plug/telemetry_test.exs
@@ -21,18 +21,28 @@ defmodule Plug.TelemetryTest do
   end
 
   setup do
-    :telemetry.attach(:start, [:plug, :call, :start], fn _, measurements, metadata, _ ->
-      send(self(), {:event, :start, measurements, metadata})
-    end, nil)
-    :telemetry.attach(:stop, [:plug, :call, :stop], fn _, measurements, metadata, _ ->
-      send(self(), {:event, :stop, measurements, metadata})
-    end, nil)
+    :telemetry.attach(
+      :start,
+      [:plug, :call, :start],
+      fn _, measurements, metadata, _ ->
+        send(self(), {:event, :start, measurements, metadata})
+      end,
+      nil
+    )
+
+    :telemetry.attach(
+      :stop,
+      [:plug, :call, :stop],
+      fn _, measurements, metadata, _ ->
+        send(self(), {:event, :stop, measurements, metadata})
+      end,
+      nil
+    )
 
     on_exit(fn ->
-     :telemetry.detach(:start)
-     :telemetry.detach(:stop)
+      :telemetry.detach(:start)
+      :telemetry.detach(:stop)
     end)
-
   end
 
   test "emits an event before the pipeline and before sending the response" do

--- a/test/plug/telemetry_test.exs
+++ b/test/plug/telemetry_test.exs
@@ -53,8 +53,8 @@ defmodule Plug.TelemetryTest do
     assert %{conn: conn} = metadata
 
     assert_received {:event, :stop, measurements, metadata}
-    assert %{time: time} = measurements
-    assert is_integer(time)
+    assert %{duration: duration} = measurements
+    assert is_integer(duration)
     assert %{conn: conn, status: 200} = metadata
     assert conn.state == :set
   end


### PR DESCRIPTION
This PR adds a Plug which can be used to instrument the pipeline with Telemetry events. There are two events right now, one emitted when this plug is invoked, and the other one emitted in a `before_send` callback. There are few things I'm not sure about, though 🤔 (similar to phoenixframework/phoenix#3300 questions).

**Event names**: I borrowed the naming from Phoenix instrumenters, although I'm not sure about them. The `stop` event is not really called when the pipeline "stops", but rather when the response is supposed to be sent. Alternatively, there could be `[:plug, :call]` or `[:plug, :request]` for *start* event, and `[:plug, :response]` for *stop* event. Also, there might be no need for the start event at all.

**Time measurement name**: I used generic "time", although I'm not sure I like it. Other candidates I thought about are "latency", "response_time", or "processing_time", although none of them is technically correct because more code might be invoked before this plug is called.

#### TODO

- [x] docs

/cc @binaryseed @bryannaegele