### PR TITLE
Fix some inconsistencies in Plug.Static responses.

### DIFF
--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -218,6 +218,7 @@ defmodule Plug.Static do
       {:fresh, conn} ->
         conn
         |> maybe_add_vary(options.gzip?, options.brotli?)
+        |> delete_resp_header("content-encoding")
         |> send_resp(304, "")
         |> halt()
     end

--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -217,6 +217,7 @@ defmodule Plug.Static do
 
       {:fresh, conn} ->
         conn
+        |> maybe_add_vary(options.gzip?, options.brotli?)
         |> send_resp(304, "")
         |> halt()
     end

--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -346,7 +346,13 @@ defmodule Plug.Static do
         file_info(size: size, mtime: mtime) = file_info
         {size, mtime} |> :erlang.phash2() |> Integer.to_string(16)
     end
+    |> maybe_add_quotes()
   end
+
+  # If the etag starts with a quote or a weak prefix we assume that it is correctly quoted.
+  defp maybe_add_quotes(<<"\"", _::binary>> = etag), do: etag
+  defp maybe_add_quotes(<<"W/\"", _::binary>> = etag), do: etag
+  defp maybe_add_quotes(etag), do: "\"" <> etag <> "\""
 
   defp file_encoding(conn, path, [_range], _gzip?, _brotli?) do
     # We do not support compression for range queries.

--- a/test/plug/static_test.exs
+++ b/test/plug/static_test.exs
@@ -61,6 +61,7 @@ defmodule Plug.StaticTest do
     assert conn.resp_body == ""
     assert get_resp_header(conn, "cache-control") == ["public"]
     assert get_resp_header(conn, "x-custom") == []
+    assert get_resp_header(conn, "vary") == ["Accept-Encoding"]
 
     assert get_resp_header(conn, "content-type") == []
     assert get_resp_header(conn, "etag") == [etag]
@@ -398,6 +399,7 @@ defmodule Plug.StaticTest do
       assert conn.resp_body == ""
       assert get_resp_header(conn, "cache-control") == ["public"]
       assert get_resp_header(conn, "x-custom") == []
+      assert get_resp_header(conn, "vary") == ["Accept-Encoding"]
 
       assert get_resp_header(conn, "content-type") == []
       assert get_resp_header(conn, "etag") == [etag]


### PR DESCRIPTION
Some responses generated by Plug.Static were not fully standard compliant. This PR fixes the following inconsistencies:

* ensure etags are quoted (https://tools.ietf.org/html/rfc7232#section-2.3)
* set `vary` header if it would have been sent in a 200 response (https://tools.ietf.org/html/rfc7232#section-4.1)
* omit `content-encoding` header in 304 responses

Regarding the last point - the RFCs are a bit unclear on whether a 304 response may contain a content-encoding, but some clients may try to decompress the empty body (e.g., https://github.com/square/okhttp/issues/268).