### PR TITLE
Support multiple active secret key bases for verifying/decrypting session cookie

### DIFF
--- a/lib/plug/session/cookie.ex
+++ b/lib/plug/session/cookie.ex
@@ -47,7 +47,7 @@ defmodule Plug.Session.COOKIE do
       list will be tried in order after the `:secret_key_base` to
       decrypt/verify. When a cookie is updated the `:secret_key_base` is always
       used to encrypt/sign. Can be either a list of binaries or an MFA
-      returning a list of binarys. Defaults to `[]`;
+      returning a list of binaries. Defaults to `[]`;
 
     * `:log` - Log level to use when the cookie cannot be decoded.
       Defaults to `:debug`, can be set to false to disable it.


### PR DESCRIPTION
To support secret rotation handled by a user library, allow cookie session store to verify/decrypt cookies with other secret key bases if the `:secret_key_base` can not verify/decrypt. However always encrypt/sign with the `:secret_key_base`. These active secrets are set by cookie session store option `:active_secret_key_bases`, which should be a list of binaries or a MFA which returns a list of binaries.

See https://github.com/elixir-plug/plug/issues/826#issuecomment-473549756.