### PR TITLE
Update documentation for session_delete/2

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1431,7 +1431,7 @@ defmodule Plug.Conn do
   end
 
   @doc """
-  Deletes the session for the given `key`.
+  Deletes a `key` from the session.
 
   The key can be a string or an atom, where atoms are
   automatically converted to strings.

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1431,7 +1431,7 @@ defmodule Plug.Conn do
   end
 
   @doc """
-  Deletes a `key` from the session.
+  Deletes `key` from session.
 
   The key can be a string or an atom, where atoms are
   automatically converted to strings.


### PR DESCRIPTION
The old description is a bit irritating in my opinion, because it says that it deletes the session, instead of just a value of the session