### PR TITLE
Only accept CSRF tokens in the body params

### DIFF
--- a/lib/plug/csrf_protection.ex
+++ b/lib/plug/csrf_protection.ex
@@ -272,7 +272,7 @@ defmodule Plug.CSRFProtection do
 
   defp verified_request?(conn, csrf_token, allow_hosts) do
     conn.method in @unprotected_methods ||
-      valid_csrf_token?(conn, csrf_token, conn.params["_csrf_token"], allow_hosts) ||
+      valid_csrf_token?(conn, csrf_token, conn.body_params["_csrf_token"], allow_hosts) ||
       valid_csrf_token?(conn, csrf_token, first_x_csrf_token(conn), allow_hosts) ||
       skip_csrf_protection?(conn)
   end

--- a/test/plug/csrf_protection_test.exs
+++ b/test/plug/csrf_protection_test.exs
@@ -107,7 +107,7 @@ defmodule Plug.CSRFProtectionTest do
 
   test "raise error for missing authenticity token in session" do
     assert_raise InvalidCSRFTokenError, fn ->
-      call(conn(:post, "/"))
+      call(conn(:post, "/", %{}))
     end
 
     assert_raise InvalidCSRFTokenError, fn ->
@@ -134,7 +134,7 @@ defmodule Plug.CSRFProtectionTest do
   end
 
   test "clear session for missing authenticity token in session" do
-    assert conn(:post, "/")
+    assert conn(:post, "/", %{})
            |> call(with: :clear_session)
            |> get_session("key") == nil
 
@@ -159,10 +159,10 @@ defmodule Plug.CSRFProtectionTest do
     conn = call(conn(:get, "/?token=get"))
     csrf_token = conn.resp_body
 
-    conn = call_with_old_conn(conn(:post, "/"), conn, with: :clear_session)
+    conn = call_with_old_conn(conn(:post, "/", %{}), conn, with: :clear_session)
     assert get_session(conn, "key") == nil
 
-    assert conn(:post, "/")
+    assert conn(:post, "/", %{})
            |> put_req_header("x-csrf-token", csrf_token)
            |> call_with_old_conn(conn, with: :clear_session)
            |> get_session("key") == "val"
@@ -301,21 +301,21 @@ defmodule Plug.CSRFProtectionTest do
     csrf_token = old_conn.resp_body
 
     conn =
-      conn(:post, "/")
+      conn(:post, "/", %{})
       |> put_req_header("x-csrf-token", csrf_token)
       |> call_with_old_conn(old_conn)
 
     refute conn.halted
 
     conn =
-      conn(:put, "/")
+      conn(:put, "/", %{})
       |> put_req_header("x-csrf-token", csrf_token)
       |> call_with_old_conn(old_conn)
 
     refute conn.halted
 
     conn =
-      conn(:patch, "/")
+      conn(:patch, "/", %{})
       |> put_req_header("x-csrf-token", csrf_token)
       |> call_with_old_conn(old_conn)
 


### PR DESCRIPTION
I thought this discussion was simplest as a PR.
https://elixir-lang.slack.com/archives/C03QQCV4H/p1556713059283400

Should CSRF protection accept tokens that are sent as query params?

Technically a secret in the host header is just as secure as the request body when sending the request to the server.

However.

1. An application might render a response rather than redirect leaving the token in the browsers url bar where an end user might be tempted to copy it else where.
2. tokens as part of a URL are more likely to end up in application logs than if they where submitted in the body