### PR TITLE
Support Nginx range requests

### DIFF
--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -269,8 +269,8 @@ defmodule Plug.Static do
     end
   end
 
-  defp check_bounds(range_start, range_end, file_size)
-       when range_start < 0 or range_end >= file_size or range_start > range_end do
+  defp check_bounds(range_start, range_end, _file_size)
+       when range_start < 0 or range_start > range_end do
     :error
   end
 
@@ -280,6 +280,10 @@ defmodule Plug.Static do
 
   defp check_bounds(_range_start, _range_end, _file_size) do
     :ok
+  end
+
+  defp send_range(conn, path, range_start, range_end, file_size) when range_end >= file_size do
+    send_range(conn, path, range_start, file_size - 1, file_size)
   end
 
   defp send_range(conn, path, range_start, range_end, file_size) do

--- a/test/plug/static_test.exs
+++ b/test/plug/static_test.exs
@@ -358,6 +358,19 @@ defmodule Plug.StaticTest do
       assert get_resp_header(conn, "content-range") == ["bytes 2-4/5"]
     end
 
+    test "serves tail of file if range end greater than file length" do
+      conn =
+        conn(:get, "/public/fixtures/static.txt", [])
+        |> put_req_header("range", "bytes=4-1024")
+        |> call()
+
+      assert conn.status == 206
+      assert conn.resp_body == "O"
+      assert get_resp_header(conn, "content-type") == ["text/plain"]
+      assert get_resp_header(conn, "accept-ranges") == ["bytes"]
+      assert get_resp_header(conn, "content-range") == ["bytes 4-4/5"]
+    end
+
     test "returns entire file if range does not contain either start or end" do
       conn =
         conn(:get, "/public/fixtures/static.txt", [])


### PR DESCRIPTION
Currently, Nginx with enabled [cache‑slice](https://www.nginx.com/blog/smart-efficient-byte-range-caching-nginx/#cache-slice) doesn't work together with Plug.Static. 😢 

The problem is that the range size in Nginx is fixed (defined in config, usually 1mb) and for the last chunk, the range could be greater than the file size.  But Plug.Static [expects the range end to be < file length](https://github.com/elixir-plug/plug/blob/v1.8.0/lib/plug/static.ex#L272), so it responds with full file and for some reason, Nginx can't handle it and sends a corrupted file to a user.

For example, let's say we have a 1.5mb file, Nginx requests a first chunk 0-1mb, gets 206, then it requests the last chunk 1-2mb but Plug.Static responses with 200 and full file which Nginx can't properly handle in this situation.

Nginx error log:
```
2019/05/22 23:15:11 [error] 2970#0: *2425 unexpected status code 200 in slice response while reading response header from upstream, client: ::1, server: localhost, request: "GET /media/d8883d2112a1d40ac423a02346806de7f7aa786c6da9d00fbbd6eb03ad50d05f.png?name=test.11.png HTTP/1.1", subrequest: "/media/d8883d2112a1d40ac423a02346806de7f7aa786c6da9d00fbbd6eb03ad50d05f.png", upstream: "http://127.0.0.1:4001/media/d8883d2112a1d40ac423a02346806de7f7aa786c6da9d00fbbd6eb03ad50d05f.png?name=test.11.png", host: "localhost:4000"
```
