### PR TITLE
Add option for custom id_generator on RequestId

### DIFF
--- a/test/plug/request_id_test.exs
+++ b/test/plug/request_id_test.exs
@@ -65,6 +65,16 @@ defmodule Plug.RequestIdTest do
     assert res_request_id == meta_request_id
   end
 
+  test "generates request id using generator function from opts, if provided" do
+    id_generator = fn -> "staticidfortestingpurposesonly" end
+
+    conn = call(conn(:get, "/"), id_generator: id_generator)
+    [res_request_id] = get_resp_header(conn, "x-request-id")
+    meta_request_id = Logger.metadata()[:request_id]
+    assert res_request_id == "staticidfortestingpurposesonly"
+    assert res_request_id == meta_request_id
+  end
+
   defp generated_request_id?(request_id) do
     Regex.match?(~r/\A[A-Za-z0-9-_]+\z/, request_id)
   end


### PR DESCRIPTION
👋 New to Elixir but thought I'd have a go at contributing something.

Allows someone to provide a function to act as the Request Id generator. This could mean implementors might do something regrettable with this power but I'm not sure of the stance the Elixir community has on protecting people from themselves?

It also seems that another way to do this without making changes to this plug would be to create a custom plug to set the `x-request-id` before this plug is called which would perhaps the preferred approach?

Not attached to this if it's a terrible idea. Figure the worst case I get to gain some experience from this process and community 🙂 

Thanks for your time.