### PR TITLE
Fix dropping session with custom max_age

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1371,7 +1371,7 @@ defmodule Plug.Conn do
   @spec delete_resp_cookie(t, binary, Keyword.t()) :: t
   def delete_resp_cookie(%Conn{resp_cookies: resp_cookies} = conn, key, opts \\ [])
       when is_binary(key) and is_list(opts) do
-    opts = [universal_time: @epoch, max_age: 0] ++ opts
+    opts = opts ++ [universal_time: @epoch, max_age: 0]
     resp_cookies = Map.put(resp_cookies, key, :maps.from_list(opts))
     update_cookies(%{conn | resp_cookies: resp_cookies}, &Map.delete(&1, key))
   end

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -878,6 +878,22 @@ defmodule Plug.ConnTest do
     assert conn.resp_cookies["foo"] == %{value: "baz", path: "/baz", secure: false}
   end
 
+  test "delete_resp_cookie/3 ignores max_age, universal_time" do
+    cookie_opts = [
+      path: "/baz",
+      max_age: 1000,
+      universal_time: {{4000, 1, 1}, {0, 0, 0}}
+    ]
+
+    conn =
+      conn(:get, "/")
+      |> delete_resp_cookie("foo", cookie_opts)
+      |> send_resp(200, "ok")
+
+    assert conn.resp_cookies["foo"].max_age == 0
+    assert conn.resp_cookies["foo"].universal_time == {{1970, 1, 1}, {0, 0, 0}}
+  end
+
   test "put_req_cookie/3 and delete_req_cookie/2" do
     conn = conn(:get, "/")
     assert get_req_header(conn, "cookie") == []


### PR DESCRIPTION
When using `Plug.Session` with a custom `max_age`:

```
  plug Plug.Session,
    store: :cookie,
    max_age: 1000,
    signing_salt: "123456789"
```

Calling `configure_session(conn, drop: true)` does not drop the session, because the cookie is sent with a max_age of 1000 rather than 0.

This is because the arguments are passed unfiltered to `delete_resp_cookie/3`. This is consistent with the documentation, which says "Deleting a cookie requires the same options as to when the cookie was put."

`delete_resp_cookie/3` should just ignore `max_age` (and `universal_time`) since they don't make sense when deleting a cookie.