### PR TITLE
Add docs note about header keys being case insensitive

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -629,7 +629,8 @@ defmodule Plug.Conn do
   Adds a new request header (`key`) if not present, otherwise replaces the
   previous value of that header with `value`.
 
-  It is recommended for header keys to be in lowercase, to avoid sending
+  Because header keys are case-insensitive in both HTTP/1.1 and HTTP/2,
+  it is recommended for header keys to be in lowercase, to avoid sending
   duplicate keys in a request.
   Additionally, requests with mixed-case headers served over HTTP/2 are not
   considered valid by common clients, resulting in dropped requests.
@@ -741,7 +742,8 @@ defmodule Plug.Conn do
   Adds a new response header (`key`) if not present, otherwise replaces the
   previous value of that header with `value`.
 
-  It is recommended for header keys to be in lowercase, to avoid sending
+  Because header keys are case-insensitive in both HTTP/1.1 and HTTP/2,
+  it is recommended for header keys to be in lowercase, to avoid sending
   duplicate keys in a request.
   Additionally, responses with mixed-case headers served over HTTP/2 are not
   considered valid by common clients, resulting in dropped responses.


### PR DESCRIPTION
The test library throwing an exception on mixed-case header keys was really confusing to me because I didn't realize that HTTP header keys are case-insensitive. I spent a bit looking up answers both in the code and in the HTTP specs, so I figured I could add a quick note in the documentation to save others the time.

If this is common knowledge and the docs change is superfluous, I totally understand if you decide to not accept the PR 😀 