### PR TITLE
Added documentation regarding HTTP/2 header casing to merge_resp_headers

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -826,6 +826,13 @@ defmodule Plug.Conn do
   @doc """
   Merges a series of response headers into the connection.
 
+  It is recommended for header keys to be in lowercase, to avoid sending
+  duplicate keys in a request.
+  Additionally, responses with mixed-case headers served over HTTP/2 are not
+  considered valid by common clients, resulting in dropped responses.
+  As a convenience, when using the `Plug.Adapters.Conn.Test` adapter, any
+  headers that aren't lowercase will raise a `Plug.Conn.InvalidHeaderError`.
+
   ## Example
 
       Plug.Conn.merge_resp_headers(conn, [{"content-type", "text/plain"}, {"X-1337", "5P34K"}])


### PR DESCRIPTION
Just ran into the same issue as #813 when using `put_secure_browser_headers` in Phoenix, but noted the note was missing from the docs of `merge_resp_headers`. Took a little while to figure out, we might as well add the note to that function, too.