### PR TITLE
use new child specifications from Supervisor module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
   include:
     - stage: test
 
-    - elixir: '1.4.0'
+    - elixir: '1.5.0'
       otp_release: '19.1'
 
     - stage: check formatted

--- a/lib/plug/supervisor.ex
+++ b/lib/plug/supervisor.ex
@@ -6,13 +6,11 @@ defmodule Plug.Supervisor do
   end
 
   def init(:ok) do
-    import Supervisor.Spec
-
     children = [
-      worker(Plug.Upload, [])
+      Plug.Upload
     ]
 
     Plug.Keys = :ets.new(Plug.Keys, [:named_table, :public, read_concurrency: true])
-    supervise(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/lib/plug/upload.ex
+++ b/lib/plug/upload.ex
@@ -144,7 +144,7 @@ defmodule Plug.Upload do
   end
 
   @doc false
-  def start_link(_) do
+  def start_link(_ \\ []) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/lib/plug/upload.ex
+++ b/lib/plug/upload.ex
@@ -144,7 +144,7 @@ defmodule Plug.Upload do
   end
 
   @doc false
-  def start_link(_ \\ []) do
+  def start_link(_) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/lib/plug/upload.ex
+++ b/lib/plug/upload.ex
@@ -144,7 +144,7 @@ defmodule Plug.Upload do
   end
 
   @doc false
-  def start_link() do
+  def start_link(_) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.MixProject do
   use Mix.Project
 
-  @version "1.8.2"
+  @version "1.9.0-dev"
   @description "A specification and conveniences for composable modules between web applications"
   @xref_exclude [Plug.Cowboy, :telemetry]
 
@@ -9,7 +9,7 @@ defmodule Plug.MixProject do
     [
       app: :plug,
       version: @version,
-      elixir: "~> 1.4",
+      elixir: "~> 1.5",
       deps: deps(),
       package: package(),
       description: @description,


### PR DESCRIPTION
`Supervisor.Spec` has been deprecated for a while. It might good to use new child specifications from [`Supervisor` module](https://hexdocs.pm/elixir/Supervisor.html)