### PR TITLE
Add documentation on using PLUG_EDITOR with vscode

### DIFF
--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -84,6 +84,9 @@ defmodule Plug.Debugger do
 
       txmt://open/?url=file://__FILE__&line=__LINE__
 
+  Or, using Visual Studio Code:
+
+      vscode://file/__FILE__:__LINE__
   """
 
   @already_sent {:plug_conn, :sent}


### PR DESCRIPTION
The correspond VS code docs were hard for me to find via google

https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls