### PR TITLE
Support the SameSite cookie attribute for improved security

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1350,9 +1350,11 @@ defmodule Plug.Conn do
     * `:max_age` - the cookie max-age, in seconds. Providing a value for this
       option will set both the _max-age_ and _expires_ cookie attributes
     * `:path` - the path the cookie applies to
-    * `:http_only` - when `false`, the cookie is accessible beyond HTTP
+    * `:http_only` - when `false`, the cookie is accessible beyond HTTP (eg, from JavaScript)
     * `:secure` - if the cookie must be sent only over https. Defaults
       to true when the connection is HTTPS
+    * `:same_site` - determines which cross-site requests, if any, may include the cookie.
+      Valid values are :lax and :strict
     * `:extra` - string to append to cookie. Use this to take advantage of
       non-standard cookie attributes.
 

--- a/lib/plug/conn/cookies.ex
+++ b/lib/plug/conn/cookies.ex
@@ -3,14 +3,6 @@ defmodule Plug.Conn.Cookies do
   Conveniences for encoding and decoding cookies.
   """
 
-  defmodule InvalidOptionError do
-    defexception message: "header is invalid"
-
-    @moduledoc ~S"""
-    Error raised when trying to set an invalid cookie header option, such as "SameSite=true".
-    """
-  end
-
   @doc """
   Decodes the given cookies as given in a request header.
 
@@ -86,7 +78,7 @@ defmodule Plug.Conn.Cookies do
   defp encode_same_site(nil), do: nil
 
   defp encode_same_site(_),
-    do: raise(InvalidOptionError, "same_site cookie option must be one of :lax, :strict, or nil")
+    do: raise(ArgumentError, "same_site cookie option must be one of :lax, :strict, or nil")
 
   defp emit_if(value, fun_or_string) do
     cond do

--- a/lib/plug/session.ex
+++ b/lib/plug/session.ex
@@ -28,6 +28,7 @@ defmodule Plug.Session do
     * `:secure` - see `Plug.Conn.put_resp_cookie/4`;
     * `:http_only` - see `Plug.Conn.put_resp_cookie/4`;
     * `:extra` - see `Plug.Conn.put_resp_cookie/4`;
+    * `:same_site` - see `Plug.Conn.put_resp_cookie/4`;
 
   Additional options can be given to the session store, see the store's
   documentation for the options it accepts.
@@ -40,7 +41,7 @@ defmodule Plug.Session do
   alias Plug.Conn
   @behaviour Plug
 
-  @cookie_opts [:domain, :max_age, :path, :secure, :http_only, :extra]
+  @cookie_opts [:domain, :max_age, :path, :secure, :http_only, :same_site, :extra]
 
   def init(opts) do
     store = Plug.Session.Store.get(Keyword.fetch!(opts, :store))

--- a/test/plug/conn/cookies_test.exs
+++ b/test/plug/conn/cookies_test.exs
@@ -39,7 +39,7 @@ defmodule Plug.Conn.CookiesTest do
 
     assert encode("foo", %{value: "bar", same_site: nil}) == "foo=bar; path=/; HttpOnly"
 
-    assert_raise Plug.Conn.Cookies.InvalidOptionError, fn ->
+    assert_raise ArgumentError, fn ->
       encode("foo", %{value: "bar", same_site: true})
     end
   end

--- a/test/plug/conn/cookies_test.exs
+++ b/test/plug/conn/cookies_test.exs
@@ -30,6 +30,20 @@ defmodule Plug.Conn.CookiesTest do
              "foo=bar; path=/; domain=google.com; HttpOnly"
   end
 
+  test "encodes with :same_site option" do
+    assert encode("foo", %{value: "bar", same_site: :lax}) ==
+             "foo=bar; path=/; HttpOnly; SameSite=Lax"
+
+    assert encode("foo", %{value: "bar", same_site: :strict}) ==
+             "foo=bar; path=/; HttpOnly; SameSite=Strict"
+
+    assert encode("foo", %{value: "bar", same_site: nil}) == "foo=bar; path=/; HttpOnly"
+
+    assert_raise Plug.Conn.Cookies.InvalidOptionError, fn ->
+      encode("foo", %{value: "bar", same_site: true})
+    end
+  end
+
   test "encodes with :secure option" do
     assert encode("foo", %{value: "bar", secure: true}) == "foo=bar; path=/; secure; HttpOnly"
   end

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -829,9 +829,13 @@ defmodule Plug.ConnTest do
     conn = send_resp(conn(:get, "/"), 200, "ok")
     assert get_resp_header(conn, "set-cookie") == []
 
-    conn = conn(:get, "/") |> put_resp_cookie("foo", "baz", path: "/baz") |> send_resp(200, "ok")
-    assert conn.resp_cookies["foo"] == %{value: "baz", path: "/baz"}
-    assert get_resp_header(conn, "set-cookie") == ["foo=baz; path=/baz; HttpOnly"]
+    conn =
+      conn(:get, "/")
+      |> put_resp_cookie("foo", "baz", path: "/baz", same_site: :lax)
+      |> send_resp(200, "ok")
+
+    assert conn.resp_cookies["foo"] == %{value: "baz", path: "/baz", same_site: :lax}
+    assert get_resp_header(conn, "set-cookie") == ["foo=baz; path=/baz; HttpOnly; SameSite=Lax"]
 
     conn =
       conn(:get, "/")

--- a/test/plug/session_test.exs
+++ b/test/plug/session_test.exs
@@ -20,6 +20,7 @@ defmodule Plug.SessionTest do
         key: "foobar",
         secure: true,
         path: "some/path",
+        same_site: :strict,
         extra: "extra"
       )
 
@@ -27,8 +28,15 @@ defmodule Plug.SessionTest do
     conn = put_session(conn, "foo", "bar")
     conn = send_resp(conn, 200, "")
 
-    assert %{"foobar" => %{value: _, secure: true, path: "some/path", extra: "extra"}} =
-             conn.resp_cookies
+    assert %{
+             "foobar" => %{
+               value: _,
+               secure: true,
+               path: "some/path",
+               extra: "extra",
+               same_site: :strict
+             }
+           } = conn.resp_cookies
 
     refute Map.has_key?(conn.resp_cookies["foobar"], :http_only)
 
@@ -39,6 +47,7 @@ defmodule Plug.SessionTest do
         store: ProcessStore,
         key: "unsafe_foobar",
         http_only: false,
+        same_site: nil,
         path: "some/path"
       )
 
@@ -46,7 +55,7 @@ defmodule Plug.SessionTest do
     conn = put_session(conn, "foo", "bar")
     conn = send_resp(conn, 200, "")
 
-    assert %{"unsafe_foobar" => %{value: _, http_only: false, path: "some/path"}} =
+    assert %{"unsafe_foobar" => %{value: _, http_only: false, path: "some/path", same_site: nil}} =
              conn.resp_cookies
   end
 


### PR DESCRIPTION
The SameSite cookie attribute determines which cross-site requests, if
any, should include the cookie. It can be used to instruct a browser
that, for example, the session cookie should not be sent along with form
submissions originating from another site, thereby preventing CSRF
attacks.

On "strict" vs "lax" modes:

> In the strict mode, the cookie is withheld with any cross-site usage.
> Even when the user follows a link to another website the cookie is not
> sent.
> In lax mode, some cross-site usage is allowed. Specifically if the
> request is a GET request and the request is top-level. Top-level means
> that the URL in the address bar changes because of this navigation.
> This is not the case for iframes, images or XMLHttpRequests.
> - http://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/

On brower compatibility:

> This feature is backwards compatible. Browsers not supporting this
> feature will simply use the cookie as a regular cookie.
> - https://caniuse.com/#search=samesite

See https://www.owasp.org/index.php/SameSite for more information.