### PR TITLE
Use HTTP status code 414 when query string is too long

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
     - stage: test
 
     - elixir: '1.5.0'
-      otp_release: '19.1'
+      otp_release: '19.3'
 
     - stage: check formatted
       script: mix format --check-formatted

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -978,7 +978,9 @@ defmodule Plug.Conn do
 
     if byte_size(query_string) > length do
       raise InvalidQueryError,
-            "maximum query string length is #{length}, got a query with #{byte_size(query_string)} bytes"
+        message:
+          "maximum query string length is #{length}, got a query with #{byte_size(query_string)} bytes",
+        plug_status: 414
     end
 
     query_params = Plug.Conn.Query.decode(query_string)


### PR DESCRIPTION
This is a more precise indication about what's wrong than a generic
"Bad Request" status code.

Also use Erlang/OTP 19.3 instead of 19.1 for the Travis build. Travis seems to have misplaced the 19.1 binary.