### PR TITLE
Percent-escape square braces in query param encoder

### DIFF
--- a/lib/plug/conn/query.ex
+++ b/lib/plug/conn/query.ex
@@ -44,12 +44,12 @@ defmodule Plug.Conn.Query do
   Encoding named lists:
 
       iex> encode(%{foo: ["bar", "baz"]})
-      "foo[]=bar&foo[]=baz"
+      "foo%5B%5D=bar&foo%5B%5D=baz"
 
   Encoding nested structures:
 
       iex> encode(%{foo: %{bar: "baz"}})
-      "foo[bar]=baz"
+      "foo%5Bbar%5D=baz"
 
   """
 
@@ -201,7 +201,7 @@ defmodule Plug.Conn.Query do
                 "got: #{inspect(value)}"
 
       value ->
-        [?&, encode_pair(parent_field <> "[]", value, encoder)]
+        [?&, encode_pair(parent_field <> "%5B%5D", value, encoder)]
     end
 
     list
@@ -229,7 +229,7 @@ defmodule Plug.Conn.Query do
           if parent_field == "" do
             encode_key(field)
           else
-            parent_field <> "[" <> encode_key(field) <> "]"
+            parent_field <> "%5B" <> encode_key(field) <> "%5D"
           end
 
         [?&, encode_pair(field, value, encoder)]

--- a/test/plug/conn/query_test.exs
+++ b/test/plug/conn/query_test.exs
@@ -106,43 +106,46 @@ defmodule Plug.Conn.QueryTest do
     assert encode(%{foo: nil}) == "foo="
     assert encode(%{foo: "bå®"}) == "foo=b%C3%A5%C2%AE"
     assert encode(%{foo: 1337}) == "foo=1337"
-    assert encode(%{foo: ["bar", "baz"]}) == "foo[]=bar&foo[]=baz"
+    assert encode(%{foo: ["bar", "baz"]}) == "foo%5B%5D=bar&foo%5B%5D=baz"
 
-    assert encode(%{users: %{name: "hello", age: 17}}) == "users[age]=17&users[name]=hello"
-    assert encode(%{users: [name: "hello", age: 17]}) == "users[name]=hello&users[age]=17"
+    assert encode(%{users: %{name: "hello", age: 17}}) ==
+             "users%5Bage%5D=17&users%5Bname%5D=hello"
+
+    assert encode(%{users: [name: "hello", age: 17]}) == "users%5Bname%5D=hello&users%5Bage%5D=17"
 
     assert encode(%{users: [name: "hello", age: 17, name: "goodbye"]}) ==
-             "users[name]=hello&users[age]=17"
+             "users%5Bname%5D=hello&users%5Bage%5D=17"
 
     assert encode(%{"my weird field": "q1!2\"'w$5&7/z8)?"}) ==
              "my+weird+field=q1%212%22%27w%245%267%2Fz8%29%3F"
 
     assert encode(%{foo: %{"my weird field": "q1!2\"'w$5&7/z8)?"}}) ==
-             "foo[my+weird+field]=q1%212%22%27w%245%267%2Fz8%29%3F"
+             "foo%5Bmy+weird+field%5D=q1%212%22%27w%245%267%2Fz8%29%3F"
 
     assert encode(%{}) == ""
     assert encode([]) == ""
 
-    assert encode(%{foo: [""]}) == "foo[]="
+    assert encode(%{foo: [""]}) == "foo%5B%5D="
 
-    assert encode(%{foo: ["bar", "baz"], bat: [1, 2]}) == "bat[]=1&bat[]=2&foo[]=bar&foo[]=baz"
+    assert encode(%{foo: ["bar", "baz"], bat: [1, 2]}) ==
+             "bat%5B%5D=1&bat%5B%5D=2&foo%5B%5D=bar&foo%5B%5D=baz"
 
-    assert encode(%{x: %{y: %{z: 1}}}) == "x[y][z]=1"
-    assert encode(%{x: %{y: %{z: [1]}}}) == "x[y][z][]=1"
-    assert encode(%{x: %{y: %{z: [1, 2]}}}) == "x[y][z][]=1&x[y][z][]=2"
-    assert encode(%{x: %{y: [%{z: 1}]}}) == "x[y][][z]=1"
-    assert encode(%{x: %{y: [%{z: [1]}]}}) == "x[y][][z][]=1"
+    assert encode(%{x: %{y: %{z: 1}}}) == "x%5By%5D%5Bz%5D=1"
+    assert encode(%{x: %{y: %{z: [1]}}}) == "x%5By%5D%5Bz%5D%5B%5D=1"
+    assert encode(%{x: %{y: %{z: [1, 2]}}}) == "x%5By%5D%5Bz%5D%5B%5D=1&x%5By%5D%5Bz%5D%5B%5D=2"
+    assert encode(%{x: %{y: [%{z: 1}]}}) == "x%5By%5D%5B%5D%5Bz%5D=1"
+    assert encode(%{x: %{y: [%{z: [1]}]}}) == "x%5By%5D%5B%5D%5Bz%5D%5B%5D=1"
   end
 
   test "encode nested lists" do
-    assert encode(%{"x" => [[[1]]]}) == "x[][][]=1"
+    assert encode(%{"x" => [[[1]]]}) == "x%5B%5D%5B%5D%5B%5D=1"
   end
 
   test "encode with custom encoder" do
     encoder = &(&1 |> to_string |> String.duplicate(2))
 
     assert encode(%{foo: "bar", baz: "bat"}, encoder) == "baz=batbat&foo=barbar"
-    assert encode(%{foo: ["bar", "baz"]}, encoder) == "foo[]=barbar&foo[]=bazbaz"
+    assert encode(%{foo: ["bar", "baz"]}, encoder) == "foo%5B%5D=barbar&foo%5B%5D=bazbaz"
     assert encode(%{foo: URI.parse("/bar")}, encoder) == "foo=%2Fbar%2Fbar"
   end
 


### PR DESCRIPTION
Currently, the `Plug.Conn.Query.encode` function encodes lists and nested maps using square brackets in the query names like so:

```
iex(5)> Plug.Conn.Query.encode(%{"a" => [1,2]})
"a[]=1&a[]=2"
iex(6)> Plug.Conn.Query.encode(%{"a" => %{"b" => 3}})
"a[b]=3"
```

But, per [RFC 3986 section 3.4](https://tools.ietf.org/html/rfc3986#section-3.4), the query string may not include characters in the general delimiters class, which includes square brackets.

```
query         = *( pchar / "/" / "?" )

pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
reserved      = gen-delims / sub-delims
gen-delims    = ":" / "/" / "?" / "#" / "[" / "]" / "@"
sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
                 / "*" / "+" / "," / ";" / "="
```

This can cause a problem with some languages/frameworks which strictly decode URLs (such as the `NSURLComponents` class in Apple's Foundation).

This PR resolves that by percent-escaping the square brackets when they're used in the query param encoder to represent lists or map keys. I simply replaced the hard-coded strings with the percent escaped equivalents since that seemed simplest, though I'm not sure if there's a more elegant solution.