### PR TITLE
Remove redundant double negation from sentence

### DIFF
--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -21,7 +21,7 @@ defmodule Plug do
 
   The result returned by `init/1` is passed as second argument to `call/2`. Note
   that `init/1` may be called during compilation and as such it must not return
-  pids, ports or values that are not specific to the runtime.
+  pids, ports or values that are specific to the runtime.
 
   The API expected by a module plug is defined as a behaviour by the
   `Plug` module (this module).


### PR DESCRIPTION
I believe this: "must not return ... that are not specific to the runtime"
should be this: "must not return ... that are specific to the runtime"

If I was wrong please close and I will take note.
Thank you for reviewing.