### PR TITLE
Add MapSet to Plug.opts type

### DIFF
--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -54,7 +54,7 @@ defmodule Plug do
   pipelines.
   """
 
-  @type opts :: binary | tuple | atom | integer | float | [opts] | %{opts => opts}
+  @type opts :: binary | tuple | atom | integer | float | [opts] | %{opts => opts} | MapSet.t()
 
   use Application
 


### PR DESCRIPTION
As per #870, this PR add `MapSet.t` to the permitted types for `Plug.opts`.