### PR TITLE
Correct default HSTS expires text in SSL moduledoc

### DIFF
--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -37,7 +37,7 @@ defmodule Plug.SSL do
 
     * `:rewrite_on` - rewrites the scheme to https based on the given headers
     * `:hsts` - a boolean on enabling HSTS or not, defaults to `true`
-    * `:expires` - seconds to expires for HSTS, defaults to `7884000` (three months)
+    * `:expires` - seconds to expires for HSTS, defaults to `31_536_000` (1 year)
     * `:preload` - a boolean to request inclusion on the HSTS preload list
        (for full set of required flags, see: [Chromium HSTS submission site](https://hstspreload.org)),
       defaults to `false`


### PR DESCRIPTION
The documentation for SSL HSTS expiration suggests that it defaults to three months, however when looking at the code: 
https://github.com/elixir-plug/plug/blob/d0ef6c7ae07398360c05ab5554faf05bce686054/lib/plug/ssl.ex#L339
it appears that it actually defaults to 1 year? This updates the moduledoc text to accurately reflect what the default is.
