### PR TITLE
Add `actions` to exceptions that implement `Plug.Exception`

### DIFF
--- a/lib/plug/exceptions.ex
+++ b/lib/plug/exceptions.ex
@@ -12,16 +12,45 @@ defprotocol Plug.Exception do
 
   @fallback_to_any true
 
+  @type action :: %{label: String.t(), handler: {module(), atom(), list()}}
+
   @doc """
   Receives an exception and returns its HTTP status code.
   """
   @spec status(t) :: Plug.Conn.status()
   def status(exception)
+
+  @doc """
+  Receives an exception and returns the possible actions that could be triggered for that error.
+  Should return a list of actions in the following structure:
+
+      %{
+        label: "Text that will be displayed in the button",
+        handler: {Module, :function, [args]}
+      }
+
+  Where:
+
+    * `label` a string/binary that names this action
+    * `handler` a MFArgs that will be executed when this action is triggered
+
+  It will be rendered in the `Plug.Debugger` generated error page as buttons showing the `label`
+  that upon pressing executes the MFArgs defined in the `handler`.
+
+  ## Examples
+
+       defimpl Plug.Exception, for: ActionableExample do
+        def actions(_), do: %{label: "Print HI", handler: {IO, :puts, ["Hi!"]}}}
+       end
+  """
+  @spec actions(t) :: [action()]
+  def actions(exception)
 end
 
 defimpl Plug.Exception, for: Any do
   def status(%{plug_status: status}) when is_integer(status), do: status
   def status(_), do: 500
+  def actions(_exception), do: []
 end
 
 defmodule Plug.BadRequestError do

--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -638,6 +638,22 @@
             font-size: <%= :math.pow(1.1, -1) %>em;
         }
     }
+
+    .action-form { margin: 10px; }
+
+    .action-button {
+        border-color: <%= @style.primary %>;
+        color: <%= @style.primary %>;
+        border-radius: 3px;
+        padding-left: 20px;
+        padding-right: 20px;
+        box-shadow: 2px 2px 2px <%= @style.accent %>
+    }
+
+    .action-button:active {
+        box-shadow: none;
+        transform: translate(2px, 2px);
+    }
     </style>
 </head>
 <body>
@@ -658,6 +674,14 @@
             <p class="detail"><%= h detail %></p>
             <% end %>
         </header>
+
+        <%= for %{label: label, encoded_handler: encoded_handler} <- @actions do %>
+            <form class="action-form" action="/__plug__/debugger/action" method="POST">
+                <input type="hidden" name="encoded_handler" value="<%= encoded_handler %>">
+                <input type="hidden" name="last_path" value="<%= @last_path %>">
+                <button class="action-button" type="submit"> <%= label %> </button>
+            </form>
+        <% end %>
 
     <%= if @banner do %>
         </div>


### PR DESCRIPTION
As to be able to trigger _things_ from the rendered error page.


### Implementation

It adds a function to the `Plug.Exception` protocol named `actions/1` that should return a list of maps with a `label` and a `handler` key which we will use later to show the action buttons.

Then when rendering the error we check if the exception raised implements both the `Plug.Exception` protocol and has a definition for the `actions/1` function, which we use to retrieve the actions for that exception.

Last but not least, we encode and sign the handlers (that are nothing more then MFArgs (`{Module, :function, [args]}`)

### Example
e.g.

If we have:

```elixir
defmodule ActionEnabledException do
  defexception message: "Actions!"
end

defimpl ActionEnabledException, for: Plug.Exception do
  def actions(_), do: [%{label: "Print Hi!", action: {IO, :puts, ["Hi"]}}]
end
```

And we raise it in a `plug` where `use Plug.Debugger` is defined:

```elixir
# ... some plug
use Plug.Debugger

def call(_conn, _opts) do
  raise ActionEnabledException
end
```

In the error page, it will show a button with the text `Print Hi!` that will call the function defined in `handler`

<details>
<summary> Action buttons </summary>
<img width="777" alt="Screenshot 2019-10-25 18 14 34" src="https://user-images.githubusercontent.com/14015177/67605088-bf93ee00-f753-11e9-916a-8fa41143c49f.png">
</details>

<details>
<summary> Code being executed </summary>
<img src="https://user-images.githubusercontent.com/14015177/67605123-d0dcfa80-f753-11e9-9d32-802fded2e4bb.png" />
</details>

<details>
<summary> Example with two actions in Phoenix </summary>
<img width="506" alt="Screenshot 2019-10-25 18 16 13" src="https://user-images.githubusercontent.com/14015177/67605159-e8b47e80-f753-11e9-90b2-0461e9094784.png">
</details>

If the description is not clear enough tell me and I will gladly improve it. :smile: