### PR TITLE
Use full name and short identifier from SPDX License List

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Finally, remember all interactions in our official spaces follow our [Code of Co
 
 ## License
 
-Plug source code is released under Apache 2 License.
+Plug source code is released under Apache License 2.0.
 Check LICENSE file for more information.
 
   [issues]: https://github.com/elixir-plug/plug/issues

--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule Plug.MixProject do
 
   defp package do
     %{
-      licenses: ["Apache 2"],
+      licenses: ["Apache-2.0"],
       maintainers: ["Gary Rennie", "José Valim"],
       links: %{"GitHub" => "https://github.com/elixir-plug/plug"},
       files: ["lib", "mix.exs", "README.md", "CHANGELOG.md", "src", ".formatter.exs"]


### PR DESCRIPTION
https://spdx.org/licenses/Apache-2.0.html

From https://hex.pm/docs/publish

> It is recommended to use SPDX License identifier.