### PR TITLE
decode response cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * [Plug] Make Plug fully compatible with new Elixir child specs
   * [Plug.Parsers] Add option to skip utf8 validation
   * [Plug.Parsers] Use HTTP status code 414 when query string is too long
+  * [Plug.Conn.Cookies] Make `decode` split on `;` only, add `:backwards` option
 
 ## v1.8.3 (2019-07-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   * [Plug] Make Plug fully compatible with new Elixir child specs
   * [Plug.Parsers] Add option to skip utf8 validation
   * [Plug.Parsers] Use HTTP status code 414 when query string is too long
-  * [Plug.Conn.Cookies] Make `decode` split on `;` only, add `:backwards` option
+  * [Plug.Conn.Cookies] Make `decode` split on `;` only, remove `$`-prefix condition
 
 ## v1.8.3 (2019-07-28)
 

--- a/lib/plug/conn/cookies.ex
+++ b/lib/plug/conn/cookies.ex
@@ -4,18 +4,36 @@ defmodule Plug.Conn.Cookies do
   """
 
   @doc """
-  Decodes the given cookies as given in a request header.
+  Decodes the given cookies as given in either a request or response header.
 
   If a cookie is invalid, it is automatically discarded from the result.
 
+  ## Options
+
+    * `:backwards` (boolean) - If `true`, comma is included in the pattern for
+      splitting the content. Otherwise, only semi-colon is used.
+
   ## Examples
 
-      iex> decode("key1=value1, key2=value2")
+      iex> decode("key1=value1;key2=value2")
       %{"key1" => "value1", "key2" => "value2"}
 
+      iex> decode("key1=value1, key2=value2", backwards: true)
+      %{"key1" => "value1", "key2" => "value2"}
+
+      iex> decode("key1=value1, key2=value2", backwards: false)
+      %{"key1" => "value1, key2=value2"}
   """
-  def decode(cookie) do
-    do_decode(:binary.split(cookie, [";", ","], [:global]), %{})
+  def decode(cookie, options \\ []) do
+    pattern =
+      options
+      |> Keyword.get(:backwards)
+      |> case do
+        true -> [";", ","]
+        _ -> ";"
+      end
+
+    do_decode(:binary.split(cookie, pattern, [:global]), %{})
   end
 
   defp do_decode([], acc), do: acc

--- a/lib/plug/conn/cookies.ex
+++ b/lib/plug/conn/cookies.ex
@@ -8,32 +8,14 @@ defmodule Plug.Conn.Cookies do
 
   If a cookie is invalid, it is automatically discarded from the result.
 
-  ## Options
-
-    * `:backwards` (boolean) - If `true`, comma is included in the pattern for
-      splitting the content. Otherwise, only semi-colon is used.
-
   ## Examples
 
       iex> decode("key1=value1;key2=value2")
       %{"key1" => "value1", "key2" => "value2"}
 
-      iex> decode("key1=value1, key2=value2", backwards: true)
-      %{"key1" => "value1", "key2" => "value2"}
-
-      iex> decode("key1=value1, key2=value2", backwards: false)
-      %{"key1" => "value1, key2=value2"}
   """
-  def decode(cookie, options \\ []) do
-    pattern =
-      options
-      |> Keyword.get(:backwards)
-      |> case do
-        true -> [";", ","]
-        _ -> ";"
-      end
-
-    do_decode(:binary.split(cookie, pattern, [:global]), %{})
+  def decode(cookie) do
+    do_decode(:binary.split(cookie, ";", [:global]), %{})
   end
 
   defp do_decode([], acc), do: acc
@@ -46,7 +28,6 @@ defmodule Plug.Conn.Cookies do
   end
 
   defp decode_kv(""), do: false
-  defp decode_kv(<<?$, _::binary>>), do: false
   defp decode_kv(<<h, t::binary>>) when h in [?\s, ?\t], do: decode_kv(t)
   defp decode_kv(kv), do: decode_key(kv, "")
 

--- a/test/plug/conn/cookies_test.exs
+++ b/test/plug/conn/cookies_test.exs
@@ -4,51 +4,21 @@ defmodule Plug.Conn.CookiesTest do
   import Plug.Conn.Cookies
   doctest Plug.Conn.Cookies
 
-  @cookies %{
-    "key1=value1, key2=value2" => %{"key1" => "value1, key2=value2"},
-    "key1=value1; key2=value2" => %{"key1" => "value1", "key2" => "value2"},
-    "key space=value, key=value space" => %{},
-    "  key1=value1 , key2=value2  " => %{"key1" => "value1 , key2=value2"},
-    "$key1=value1, key2=value2; $key3=value3" => %{},
-    "" => %{},
-    "key, =, value" => %{},
-    "key=" => %{"key" => ""},
-    "key1=;;key2=" => %{"key1" => "", "key2" => ""},
-    "key1=value, with, commas;key2=" => %{"key1" => "value, with, commas", "key2" => ""}
-  }
-
   test "decode cookies" do
-    Enum.each(@cookies, fn {content, expected} ->
-      assert decode(content) == expected
-    end)
+    assert decode("key1=value1, key2=value2") == %{"key1" => "value1, key2=value2"}
+    assert decode("key1=value1; key2=value2") == %{"key1" => "value1", "key2" => "value2"}
 
-    Enum.each(@cookies, fn {content, expected} ->
-      assert decode(content, backwards: false) == expected
-    end)
-
-    Enum.each(@cookies, fn {content, expected} ->
-      assert decode(content, other: true) == expected
-    end)
-  end
-
-  test "decodes cookies backwards option" do
-    assert decode("key1=value1, key2=value2", backwards: true) == %{
-             "key1" => "value1",
-             "key2" => "value2"
+    assert decode("$key1=value1, key2=value2; $key3=value3") == %{
+             "$key1" => "value1, key2=value2",
+             "$key3" => "value3"
            }
 
-    assert decode("$key1=value1, key2=value2; $key3=value3", backwards: true) == %{
-             "key2" => "value2"
-           }
-
-    assert decode("key space=value, key=value space", backwards: true) == %{
-             "key" => "value space"
-           }
-
-    assert decode("  key1=value1 , key2=value2  ", backwards: true) == %{
-             "key1" => "value1",
-             "key2" => "value2"
-           }
+    assert decode("key space=value, key=value space") == %{}
+    assert decode("  key1=value1 , key2=value2  ") == %{"key1" => "value1 , key2=value2"}
+    assert decode("") == %{}
+    assert decode("key, =, value") == %{}
+    assert decode("key=") == %{"key" => ""}
+    assert decode("key1=;;key2=") == %{"key1" => "", "key2" => ""}
   end
 
   test "decodes encoded cookie" do


### PR DESCRIPTION
I was trying to use tesla/mint to hit an api that uses cookie-based auth from within a phoenix app. I tried parsing the cookie using `Plug.Conn.Cookies.decode/1`, but the expires value was being cut off after the short day, due to the comma.

It seems [RFC6265](https://tools.ietf.org/html/rfc6265#section-4.1) excludes commas from the split list. I've found this [PR](https://github.com/benoitc/hackney/pull/193) on hackney that seems to confirm. The original doc for `decode/1` specified request header, so if it should stay that way, I will understand.

This also gives a nice parity to this module as it can now decode its own `encode/2` output.