### PR TITLE
allow empty maps in typespecs

### DIFF
--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -54,7 +54,15 @@ defmodule Plug do
   pipelines.
   """
 
-  @type opts :: binary | tuple | atom | integer | float | [opts] | %{opts => opts} | MapSet.t()
+  @type opts ::
+          binary
+          | tuple
+          | atom
+          | integer
+          | float
+          | [opts]
+          | %{optional(opts) => opts}
+          | MapSet.t()
 
   use Application
 

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -123,22 +123,22 @@ defmodule Plug.Conn do
   """
 
   @type adapter :: {module, term}
-  @type assigns :: %{atom => any}
+  @type assigns :: %{optional(atom) => any}
   @type before_send :: [(t -> t)]
   @type body :: iodata
-  @type cookies :: %{binary => binary}
+  @type cookies :: %{optional(binary) => binary}
   @type halted :: boolean
   @type headers :: [{binary, binary}]
   @type host :: binary
   @type int_status :: non_neg_integer | nil
   @type owner :: pid
   @type method :: binary
-  @type query_param :: binary | %{binary => query_param} | [query_param]
-  @type query_params :: %{binary => query_param}
-  @type params :: %{binary => term}
+  @type query_param :: binary | %{optional(binary) => query_param} | [query_param]
+  @type query_params :: %{optional(binary) => query_param}
+  @type params :: %{optional(binary) => term}
   @type port_number :: :inet.port_number()
   @type query_string :: String.t()
-  @type resp_cookies :: %{binary => %{}}
+  @type resp_cookies :: %{optional(binary) => %{}}
   @type scheme :: :http | :https
   @type secret_key_base :: binary | nil
   @type segments :: [binary]
@@ -1437,7 +1437,7 @@ defmodule Plug.Conn do
 
   Raises if the session was not yet fetched.
   """
-  @spec get_session(t) :: %{String.t() => any}
+  @spec get_session(t) :: %{optional(String.t()) => any}
   def get_session(%Conn{private: private}) do
     if session = Map.get(private, :plug_session) do
       session

--- a/lib/plug/conn/utils.ex
+++ b/lib/plug/conn/utils.ex
@@ -3,7 +3,7 @@ defmodule Plug.Conn.Utils do
   Utilities for working with connection data
   """
 
-  @type params :: %{binary => binary}
+  @type params :: %{optional(binary) => binary}
 
   @upper ?A..?Z
   @lower ?a..?z

--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -217,7 +217,7 @@ defmodule Plug.Test do
   If the session has already been initialized, the new contents will be merged
   with the previous ones.
   """
-  @spec init_test_session(Conn.t(), %{(String.t() | atom) => any}) :: Conn.t()
+  @spec init_test_session(Conn.t(), %{optional(String.t() | atom) => any}) :: Conn.t()
   def init_test_session(conn, session) do
     conn =
       if conn.private[:plug_session_fetch] do


### PR DESCRIPTION
I am the author of https://github.com/msz/hammox, a library for type checking mocks and implementations in tests. In includes its own type checking engine based off typespec documentation.

When using Hammox I noticed some typespecs in Plug are not exactly right. For example `Plug.Conn.query_params()` is declared as `%{binary => query_param}`, which is shorthand for `%{required(binary) => query_param}`, a map with at least one key-value pair matching `binary => query_param`. However, it makes sense for the params to be empty, and the `Plug.Test.conn/3` test helper is producing `Conn`s with empty `path_params` by default. This unfortunately means that `Plug.Conn.t()` can't be used with a strict type checker like Hammox.

This PR changes the typespecs to use optional keys where I believe the intention was to allow empty maps.