### PR TITLE
Remove double assert

### DIFF
--- a/test/plug/telemetry_test.exs
+++ b/test/plug/telemetry_test.exs
@@ -69,7 +69,6 @@ defmodule Plug.TelemetryTest do
     assert map_size(measurements) == 1
     assert %{duration: duration} = measurements
     assert is_integer(duration)
-    assert is_integer(time)
     assert map_size(metadata) == 2
     assert %{conn: conn, options: [extra_options: :hello]} = metadata
     assert conn.state == :set


### PR DESCRIPTION
`time` is already asserted to be an integer on line 64 as it is part of the start event, and not the stop event