### PR TITLE
WIP: Add ability for multipart parser to decode compressed content

### DIFF
--- a/lib/plug/body_reader.ex
+++ b/lib/plug/body_reader.ex
@@ -1,0 +1,6 @@
+defmodule Plug.BodyReader do
+  @callback init(Plug.Conn.t(), opts :: Keyword.t()) :: {:ok, Plug.Conn.t()} | {:error, term}
+  @callback close(Plug.Conn.t(), opts :: Keyword.t()) :: {:ok, Plug.Conn.t()} | {:error, term}
+  @callback read_body(Plug.Conn.t(), opts :: Keyword.t()) ::
+              {:ok, binary, Plug.Conn.t()} | {:more, binary, Plug.Conn.t()} | {:error, term}
+end

--- a/lib/plug/body_reader/deflate.ex
+++ b/lib/plug/body_reader/deflate.ex
@@ -1,0 +1,52 @@
+defmodule Plug.BodyReader.Deflate do
+  def init(%Plug.Conn{} = conn, _opts) do
+    zlib_stream =
+      case content_encoding(conn) do
+        encoding when encoding in [:zlib, :gzip] ->
+          zlib_stream = :zlib.open()
+          :ok = :zlib.inflateInit(zlib_stream, window_bits_for_encoding(encoding))
+          zlib_stream
+
+        :none ->
+          nil
+      end
+
+    private =
+      conn.private
+      |> Map.put(__MODULE__, zlib_stream)
+
+    {:ok, %Plug.Conn{conn | private: private}}
+  end
+
+  def close(%Plug.Conn{private: %{__MODULE__ => zlib_stream}} = conn, _opts) do
+    if !is_nil(zlib_stream) do
+      :zlib.close(zlib_stream)
+    end
+
+    {:ok, %Plug.Conn{conn | private: Map.delete(conn.private, __MODULE__)}}
+  end
+
+  def read_body(%Plug.Conn{private: %{__MODULE__ => nil}} = conn, opts) do
+    Plug.Conn.read_body(conn, opts)
+  end
+
+  def read_body(%Plug.Conn{private: %{__MODULE__ => zlib_stream}} = conn, opts) do
+    with {:ok, body, conn} <- Plug.Conn.read_body(conn, opts) do
+      case :zlib.safeInflate(zlib_stream, body) do
+        {_, data} -> {:ok, IO.iodata_to_binary(data), conn}
+      end
+    end
+  end
+
+  defp content_encoding(conn) do
+    case Plug.Conn.get_req_header(conn, "content-encoding") do
+      ["gzip"] -> :gzip
+      ["deflate"] -> :deflate
+      [encoding] -> raise Plug.Parsers.ContentEncodingNotSupportedError, encoding: encoding
+      _ -> :none
+    end
+  end
+
+  defp window_bits_for_encoding(:zlib), do: 15
+  defp window_bits_for_encoding(:gzip), do: 47
+end

--- a/lib/plug/body_reader/deflate.ex
+++ b/lib/plug/body_reader/deflate.ex
@@ -20,6 +20,7 @@ defmodule Plug.BodyReader.Deflate do
 
   def close(%Plug.Conn{private: %{__MODULE__ => zlib_stream}} = conn, _opts) do
     if !is_nil(zlib_stream) do
+      :zlib.inflateEnd(zlib_stream)
       :zlib.close(zlib_stream)
     end
 

--- a/lib/plug/body_reader/deflate.ex
+++ b/lib/plug/body_reader/deflate.ex
@@ -1,4 +1,7 @@
 defmodule Plug.BodyReader.Deflate do
+  @behaviour Plug.BodyReader
+
+  @spec init(Plug.Conn.t(), Keyword.t()) :: {:ok, Plug.Conn.t()} | {:error, term}
   def init(%Plug.Conn{} = conn, _opts) do
     zlib_stream =
       case content_encoding(conn) do
@@ -18,6 +21,7 @@ defmodule Plug.BodyReader.Deflate do
     {:ok, %Plug.Conn{conn | private: private}}
   end
 
+  @spec close(Plug.Conn.t(), Keyword.t()) :: {:ok, Plug.Conn.t()} | {:error, term}
   def close(%Plug.Conn{private: %{__MODULE__ => zlib_stream}} = conn, _opts) do
     if !is_nil(zlib_stream) do
       :ok = :zlib.inflateEnd(zlib_stream)
@@ -27,6 +31,8 @@ defmodule Plug.BodyReader.Deflate do
     {:ok, %Plug.Conn{conn | private: Map.delete(conn.private, __MODULE__)}}
   end
 
+  @spec read_body(Plug.Conn.t(), Keyword.t()) ::
+          {:ok, binary, Plug.Conn.t()} | {:more, binary, Plug.Conn.t()} | {:error, term}
   def read_body(%Plug.Conn{private: %{__MODULE__ => nil}} = conn, opts) do
     Plug.Conn.read_body(conn, opts)
   end

--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -43,6 +43,19 @@ defmodule Plug.Parsers do
     end
   end
 
+  defmodule ContentEncodingNotSupportedError do
+    @moduledoc """
+    Error raised when the request body is compressed using an encoding that is
+    not supported.
+    """
+
+    defexception [:encoding]
+
+    def message(%{encoding: encoding}) do
+      "content encoding not supported: #{encoding}"
+    end
+  end
+
   @moduledoc """
   A plug for parsing the request body.
 

--- a/lib/plug/parsers/urlencoded.ex
+++ b/lib/plug/parsers/urlencoded.ex
@@ -22,22 +22,28 @@ defmodule Plug.Parsers.URLENCODED do
 
   def init(opts) do
     opts = Keyword.put_new(opts, :length, 1_000_000)
-    Keyword.pop(opts, :body_reader, {Plug.Conn, :read_body, []})
+    Keyword.pop(opts, :body_reader, Plug.BodyReader.Deflate)
   end
 
-  def parse(conn, "application", "x-www-form-urlencoded", _headers, {{mod, fun, args}, opts}) do
-    case apply(mod, fun, [conn, opts | args]) do
-      {:ok, body, conn} ->
-        {:ok, Plug.Conn.Query.decode(body, %{}, Plug.Parsers.BadEncodingError), conn}
+  def parse(conn, "application", "x-www-form-urlencoded", _headers, {body_reader, opts}) do
+    {:ok, conn} = body_reader.init(conn, opts)
 
-      {:more, _data, conn} ->
-        {:error, :too_large, conn}
+    try do
+      case body_reader.read_body(conn, opts) do
+        {:ok, body, conn} ->
+          {:ok, Plug.Conn.Query.decode(body, %{}, Plug.Parsers.BadEncodingError), conn}
 
-      {:error, :timeout} ->
-        raise Plug.TimeoutError
+        {:more, _data, conn} ->
+          {:error, :too_large, conn}
 
-      {:error, _} ->
-        raise Plug.BadRequestError
+        {:error, :timeout} ->
+          raise Plug.TimeoutError
+
+        {:error, _} ->
+          raise Plug.BadRequestError
+      end
+    after
+      body_reader.close(conn, opts)
     end
   end
 

--- a/test/plug/parsers/json_test.exs
+++ b/test/plug/parsers/json_test.exs
@@ -45,6 +45,10 @@ defmodule Plug.Parsers.JSONTest do
   end
 
   defmodule BodyReader do
+    def init(conn, _opts), do: {:ok, conn}
+
+    def close(conn, _opts), do: {:ok, conn}
+
     def read_body(conn, opts) do
       {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
       {:ok, String.replace(body, "foo", "fooBAR"), conn}
@@ -117,18 +121,9 @@ defmodule Plug.Parsers.JSONTest do
     conn =
       ~s({query: "foo"})
       |> json_conn()
-      |> parse(body_reader: {BodyReader, :read_body, []})
+      |> parse(body_reader: BodyReader)
 
     assert conn.params["query"] == "fooBAR"
-  end
-
-  test "parses with custom body reader and extra args" do
-    conn =
-      ~s({query: "foo"})
-      |> json_conn()
-      |> parse(body_reader: {BodyReader, :read_body, ["test", "read body"]})
-
-    assert conn.params["query"] == "fooBAZ"
   end
 
   test "expects a json decoder" do

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -306,6 +306,46 @@ defmodule Plug.ParsersTest do
     assert part3.headers == []
   end
 
+  test "parses multipart body compressed with zlib" do
+    multipart = """
+    ------w58EW1cEpjzydSCq\r
+    Content-Disposition: form-data; name=\"name\"\r
+    \r
+    hello\r
+    ------w58EW1cEpjzydSCq\r
+    Content-Type: application/json\r
+    \r
+    {"indisposed": "json"}\r
+    ------w58EW1cEpjzydSCq\r
+    Content-Type: application/octet-stream\r
+    X-My-Foo: bar\r
+    \r
+    foo\r
+    ------w58EW1cEpjzydSCq\r
+    \r
+    No content-type? No problem!\r
+    ------w58EW1cEpjzydSCq--\r
+    """
+
+    encoded_body = :zlib.compress(multipart)
+
+    %{params: params} =
+      conn(:post, "/", encoded_body)
+      |> put_req_header("content-type", "multipart/mixed; boundary=----w58EW1cEpjzydSCq")
+      |> put_req_header("content-encoding", "deflate")
+      |> parse(include_unnamed_parts_at: "_parts")
+
+    assert params["name"] == "hello"
+
+    assert [part1, part2, part3] = params["_parts"]
+    assert part1.body == "{\"indisposed\": \"json\"}"
+    assert part1.headers == [{"content-type", "application/json"}]
+    assert part2.body == "foo"
+    assert part2.headers == [{"x-my-foo", "bar"}, {"content-type", "application/octet-stream"}]
+    assert part3.body == "No content-type? No problem!"
+    assert part3.headers == []
+  end
+
   test "parses with custom body reader" do
     conn = conn(:post, "/?query=elixir", "body=foo")
 

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -4,6 +4,10 @@ defmodule Plug.ParsersTest do
   use Plug.Test
 
   defmodule BodyReader do
+    def init(conn, _opts), do: {:ok, conn}
+
+    def close(conn, _opts), do: {:ok, conn}
+
     def read_body(conn, opts) do
       {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
       {:ok, body <> "BAR", conn}
@@ -291,22 +295,10 @@ defmodule Plug.ParsersTest do
     conn =
       conn
       |> put_req_header("content-type", "application/x-www-form-urlencoded")
-      |> parse(body_reader: {BodyReader, :read_body, []})
+      |> parse(body_reader: BodyReader)
 
     assert conn.params["query"] == "elixir"
     assert conn.params["body"] == "fooBAR"
-  end
-
-  test "parses with custom body reader and extra args" do
-    conn = conn(:post, "/?query=elixir", "body=foo")
-
-    conn =
-      conn
-      |> put_req_header("content-type", "application/x-www-form-urlencoded")
-      |> parse(body_reader: {BodyReader, :read_body, ["test", "read body"]})
-
-    assert conn.params["query"] == "elixir"
-    assert conn.params["body"] == "fooBAZ"
   end
 
   test "raises on invalid url encoded" do

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -266,6 +266,46 @@ defmodule Plug.ParsersTest do
     assert params == %{}
   end
 
+  test "parses multipart body compressed with gzip" do
+    multipart = """
+    ------w58EW1cEpjzydSCq\r
+    Content-Disposition: form-data; name=\"name\"\r
+    \r
+    hello\r
+    ------w58EW1cEpjzydSCq\r
+    Content-Type: application/json\r
+    \r
+    {"indisposed": "json"}\r
+    ------w58EW1cEpjzydSCq\r
+    Content-Type: application/octet-stream\r
+    X-My-Foo: bar\r
+    \r
+    foo\r
+    ------w58EW1cEpjzydSCq\r
+    \r
+    No content-type? No problem!\r
+    ------w58EW1cEpjzydSCq--\r
+    """
+
+    encoded_body = :zlib.gzip(multipart)
+
+    %{params: params} =
+      conn(:post, "/", encoded_body)
+      |> put_req_header("content-type", "multipart/mixed; boundary=----w58EW1cEpjzydSCq")
+      |> put_req_header("content-encoding", "gzip")
+      |> parse(include_unnamed_parts_at: "_parts")
+
+    assert params["name"] == "hello"
+
+    assert [part1, part2, part3] = params["_parts"]
+    assert part1.body == "{\"indisposed\": \"json\"}"
+    assert part1.headers == [{"content-type", "application/json"}]
+    assert part2.body == "foo"
+    assert part2.headers == [{"x-my-foo", "bar"}, {"content-type", "application/octet-stream"}]
+    assert part3.body == "No content-type? No problem!"
+    assert part3.headers == []
+  end
+
   test "parses with custom body reader" do
     conn = conn(:post, "/?query=elixir", "body=foo")
 


### PR DESCRIPTION
Hi,

this is a proof-of-concept implementation to get feedback about the implementation itself, there are no docs/tests yet.

Background: https://github.com/elixir-plug/plug/issues/886

The idea of the implementation is to add a `BodyReader` behaviour with 3 callbacks: `init/2`, `read_body/2` and `close/2`.

Plug would provide `Plug.BodyReader.Deflate` out-of-the-box as a default, which relies directly on `Plug.Conn.read_body/2` if no `Content-Encoding` is provided. If there is a `Content-Encoding` header and we support the encoding used, we "inflate" the body before returning it.

`init/2` and `close/2` are required as we rely on `:zlib` (http://erlang.org/doc/man/zlib.html) and we need to make sure we close the zlib stream when finished.