### PR TITLE
Plug.Parsers: Make multipart support MFA for length limit

### DIFF
--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -183,6 +183,41 @@ defmodule Plug.ParsersTest do
     assert file.filename == "żółć.txt"
   end
 
+  test "multipart legth accepts MFA evaluated on request" do
+    multipart = """
+    ------w58EW1cEpjzydSCq\r
+    Content-Disposition: form-data; name=\"name\"\r
+    \r
+    hello\r
+    ------w58EW1cEpjzydSCq--\r
+    """
+
+    {:ok, _agent} = Agent.start_link(fn -> 0 end, name: :multipart_length)
+
+    defmodule LengthGetter do
+      def get() do
+        Agent.get(:multipart_length, & &1)
+      end
+    end
+
+    opts = Plug.Parsers.init(parsers: [{:multipart, length: {LengthGetter, :get, []}}])
+
+    assert_raise Plug.Parsers.RequestTooLargeError, fn ->
+      conn(:post, "/", multipart)
+      |> put_req_header("content-type", "multipart/mixed; boundary=----w58EW1cEpjzydSCq")
+      |> Plug.Parsers.call(opts)
+    end
+
+    Agent.update(:multipart_length, fn _ -> 10_000 end)
+
+    %{params: params} =
+      conn(:post, "/", multipart)
+      |> put_req_header("content-type", "multipart/mixed; boundary=----w58EW1cEpjzydSCq")
+      |> Plug.Parsers.call(opts)
+
+    assert params["name"] == "hello"
+  end
+
   test "multipart bodies with unnamed body parts opt" do
     multipart = """
     ------w58EW1cEpjzydSCq\r


### PR DESCRIPTION
As discussed with @josevalim in
https://git.pleroma.social/pleroma/pleroma/issues/1480#note_48420