### PR TITLE
Accept MFA for Plug.Static :header option

### DIFF
--- a/test/plug/static_test.exs
+++ b/test/plug/static_test.exs
@@ -561,4 +561,23 @@ defmodule Plug.StaticTest do
     conn = FilterPlug.call(conn(:get, "/file-deadbeef.txt"), [])
     assert conn.status == 200
   end
+
+  defmodule HeaderGenerator do
+    def generate(_conn, header) do
+      [header]
+    end
+  end
+
+  test "MFA headers" do
+    opts = [
+      at: "/public",
+      from: Path.expand("..", __DIR__),
+      headers: {HeaderGenerator, :generate, [{"x-custom", "x-value"}]}
+    ]
+
+    conn = Plug.Static.call(conn(:get, "/public/fixtures/static.txt"), Plug.Static.init(opts))
+
+    assert conn.status == 200
+    assert get_resp_header(conn, "x-custom") == ["x-value"]
+  end
 end


### PR DESCRIPTION
Allows for generating headers at runtime, e.g. setting a
'Access-Control-Allow-Origin' header for fonts based on runtime config.