### PR TITLE
Update incorrect spec in Adapter callback chunk/2

### DIFF
--- a/lib/plug/conn/adapter.ex
+++ b/lib/plug/conn/adapter.ex
@@ -71,7 +71,7 @@ defmodule Plug.Conn.Adapter do
   implementation returns the actual body and payload so
   it can be used during testing.
   """
-  @callback chunk(payload, Conn.status()) ::
+  @callback chunk(payload, Conn.body()) ::
               :ok | {:ok, sent_body :: binary, payload} | {:error, term}
 
   @doc """


### PR DESCRIPTION
The `Plug.Conn.Adapter.chunk/2` callback spec incorrectly specifies the type `Conn.status()` as the second argument's type when it should be a type which matches a potential chunk to be sent, such as `iodata`. This PR suggests to change the type to `Conn.body()`, which is `iodata`.

`Plug.Conn` code which calls the adapter callback `chunk/2` shown here
https://github.com/elixir-plug/plug/blob/231004a94f897f80a9199be2b818126ab6885734/lib/plug/conn.ex#L520

And mismatched callback spec shown here:
https://github.com/elixir-plug/plug/blob/bf379c53e8c01e3ca24713a7702053d43ed00743/lib/plug/conn/adapter.ex#L74-L75