### PR TITLE
Fix unhandled malformed URI ArgumentError

### DIFF
--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -248,7 +248,13 @@ defmodule Plug.Router do
 
       @doc false
       def match(conn, _opts) do
-        do_match(conn, conn.method, Enum.map(conn.path_info, &URI.decode/1), conn.host)
+        try do
+          do_match(conn, conn.method, Enum.map(conn.path_info, &URI.decode/1), conn.host)
+        catch
+          kind, %ArgumentError{message: "malformed URI " <> uri} = reason ->
+            reason = %Plug.Router.MalformedURIError{message: reason.message}
+            Plug.Conn.WrapperError.reraise(conn, kind, reason, __STACKTRACE__)
+        end
       end
 
       @doc false

--- a/lib/plug/router/utils.ex
+++ b/lib/plug/router/utils.ex
@@ -2,6 +2,10 @@ defmodule Plug.Router.InvalidSpecError do
   defexception message: "invalid route specification"
 end
 
+defmodule Plug.Router.MalformedURIError do
+  defexception message: "malformed URI", plug_status: 400
+end
+
 defmodule Plug.Router.Utils do
   @moduledoc false
 

--- a/test/plug/router_test.exs
+++ b/test/plug/router_test.exs
@@ -394,6 +394,17 @@ defmodule Plug.RouterTest do
     end
   end
 
+  test "handle malformed URI through error wrapper" do
+    try do
+      call(Sample, conn(:get, "/%"))
+      flunk("oops")
+    rescue
+      e in Plug.Conn.WrapperError ->
+        %{kind: :error, reason: %Plug.Router.MalformedURIError{}} = e
+        assert_received @already_sent
+    end
+  end
+
   test "match_path/1" do
     conn = call(Sample, conn(:get, "/params/get/a_value"))
     assert Plug.Router.match_path(conn) == "/params/get/:param"


### PR DESCRIPTION
Fixes #754 

`Plug.Router` currently raises an `ArgumentError: malformed URI "/%"` when a match is attempted on an invalid URI.  This patch creates a `Plug.Router.MalformedURIError` (with the status code set to `400`) in order to allow `handle_errors` to handle the exception.  The error is rescued in `match` and wrapped in `Plug.Conn.WrapperError`.

Since it looks like the error handler behavior is already tested in the `Plug.RouterTest.Forward` definition, I instead opted out of redefining the error handler to retest that behavior (that it would return a 400 status code, etc).  Instead, the exception is asserted.  Happy to add these additional assertions if necessary.