### PR TITLE
Allow to use atoms as statuses

### DIFF
--- a/lib/plug/exceptions.ex
+++ b/lib/plug/exceptions.ex
@@ -48,7 +48,7 @@ defprotocol Plug.Exception do
 end
 
 defimpl Plug.Exception, for: Any do
-  def status(%{plug_status: status}) when is_integer(status), do: status
+  def status(%{plug_status: status}), do: Plug.Conn.Status.code(status)
   def status(_), do: 500
   def actions(_exception), do: []
 end


### PR DESCRIPTION
I like to use atoms as statuses like we do it in Sinatra for example. It's actually supported in `Plug.conn.put_status/2` and some other places but not in `Plug.Exception.status/1`. I think it's good to add support in all places to keep it consistent.

Not sure whether should I add a new test for it or not. If you think so, please let me know and I will prepare it.