### PR TITLE
Remove mention to Plug.Conn.resp_charset from doc

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -51,8 +51,8 @@ defmodule Plug.Conn do
   These fields contain response information:
 
     * `resp_body` - the response body, by default is an empty string. It is set
-      to nil after the response is sent, except for test connections.
-    * `resp_charset` - the response charset, defaults to "utf-8"
+      to nil after the response is sent, except for test connections. The response 
+      charset used defaults to "utf-8".
     * `resp_cookies` - the response cookies with their name and options
     * `resp_headers` - the response headers as a list of tuples, by default `cache-control`
       is set to `"max-age=0, private, must-revalidate"`. Note, response headers


### PR DESCRIPTION
Remove mention to `Plug.Conn.resp_charset` from the documentation since this field does not actually exist (and never did). The only mention I found of that field is in 4b87bed7954e28b770fd9bc4fbb0682816143cf3.