### PR TITLE
Add option of getting host depending on anything from conn (especially custom headers)

### DIFF
--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -61,13 +61,8 @@ defmodule Plug.Test do
 
   """
   @spec conn(String.Chars.t(), binary, params) :: Conn.t()
-  def conn(method, path, params_or_body \\ nil, req_headers \\ []) do
-    Plug.Adapters.Test.Conn.conn(
-      %Plug.Conn{req_headers: req_headers},
-      method,
-      path,
-      params_or_body
-    )
+  def conn(method, path, params_or_body \\ nil) do
+    Plug.Adapters.Test.Conn.conn(%Plug.Conn{}, method, path, params_or_body)
   end
 
   @doc """

--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -61,8 +61,13 @@ defmodule Plug.Test do
 
   """
   @spec conn(String.Chars.t(), binary, params) :: Conn.t()
-  def conn(method, path, params_or_body \\ nil) do
-    Plug.Adapters.Test.Conn.conn(%Plug.Conn{}, method, path, params_or_body)
+  def conn(method, path, params_or_body \\ nil, req_headers \\ []) do
+    Plug.Adapters.Test.Conn.conn(
+      %Plug.Conn{req_headers: req_headers},
+      method,
+      path,
+      params_or_body
+    )
   end
 
   @doc """

--- a/test/plug/ssl_test.exs
+++ b/test/plug/ssl_test.exs
@@ -239,6 +239,21 @@ defmodule Plug.SSLTest do
       assert conn.halted
     end
 
+    test "to tuple host with a custom header on get" do
+      defmodule TestNamespace do
+        def get_host(conn, header_name), do: conn |> Plug.Conn.get_req_header(header_name) |> hd()
+      end
+
+      conn =
+        call(conn(:get, "http://example.com/", [], [{"x-forwarded-host", "truessl.example.com"}]),
+          host: {TestNamespace, :get_host, [:conn, "x-forwarded-host"]}
+        )
+
+      assert get_resp_header(conn, "location") == ["https://truessl.example.com/"]
+      assert conn.status == 301
+      assert conn.halted
+    end
+
     test "to host on head" do
       conn = call(conn(:head, "http://example.com/"))
       assert conn.status == 301


### PR DESCRIPTION
We have the following problem: we are using a custom HTTP header (`x-forwarded-host`) to pass host used to access reverse proxy in our system. Then the request is routed to the internal system, but with `host` header changed.

We want to enforce SSL, but therefore we need a way to redirect to location taken from other req_header from `conn`. Hence this PR - which allows changing redirect based on the content of `conn` struct.