### PR TITLE
Improve developer experience within the test adapter

### DIFF
--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -175,6 +175,7 @@ defmodule Plug.Adapters.Test.Conn do
   defp stringify_all_params([_ | _] = params), do: Enum.map(params, &stringify_all_params/1)
   defp stringify_all_params(%{__struct__: mod} = struct) when is_atom(mod), do: struct
   defp stringify_all_params(%{} = params), do: Enum.into(params, %{}, &stringify_pair/1)
+  defp stringify_all_params(fun) when is_function(fun), do: fun
   defp stringify_all_params(other), do: to_string(other)
 
   defp stringify_pair({k, v}), do: {to_string(k), stringify_all_params(v)}

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -49,6 +49,13 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert conn.params == %{"a" => "b", "file" => %{"__struct__" => "Foo"}}
   end
 
+  test "custom function params" do
+    conn = conn(:get, "/", action: fn -> "this is fine" end)
+
+    assert %{"action" => action} = conn.params
+    assert conn.params["action"].() == "this is fine"
+  end
+
   test "no body or params" do
     conn = conn(:get, "/")
     {adapter, state} = conn.adapter

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -24,6 +24,14 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
     assert conn.params == %{"a" => %{"b" => "0", "c" => "5"}, "d" => [%{"e" => "f"}]}
 
+    conn = conn(:get, "/?foo=bar", %{foo: "baz"})
+    assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+    assert conn.params == %{"foo" => "baz"}
+
+    conn = conn(:get, "/?foo=bar", %{biz: "baz"})
+    assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+    assert conn.params == %{"foo" => "bar", "biz" => "baz"}
+
     conn = conn(:get, "/?f=g", a: "b", c: [d: "e"])
     assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
     assert conn.params == %{"a" => "b", "c" => %{"d" => "e"}, "f" => "g"}

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -15,17 +15,22 @@ defmodule Plug.Adapters.Test.ConnTest do
   end
 
   test "custom params" do
-    conn = conn(:get, "/", a: "b", c: [%{d: "e"}])
-    assert conn.body_params == %{"a" => "b", "c" => [%{"d" => "e"}]}
-    assert conn.params == %{"a" => "b", "c" => [%{"d" => "e"}]}
+    conn = conn(:head, "/posts", page: 2)
+    assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+    assert conn.params == %{"page" => "2"}
+    assert conn.req_headers == []
 
-    conn = conn(:get, "/", a: "b", c: [d: "e"])
-    assert conn.body_params == %{"a" => "b", "c" => %{"d" => "e"}}
-    assert conn.params == %{"a" => "b", "c" => %{"d" => "e"}}
+    conn = conn(:get, "/", a: [b: 0, c: 5], d: [%{e: "f"}])
+    assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+    assert conn.params == %{"a" => %{"b" => "0", "c" => "5"}, "d" => [%{"e" => "f"}]}
 
-    conn = conn(:post, "/?foo=bar", %{foo: "baz"})
-    assert conn.body_params == %{"foo" => "baz"}
-    assert conn.params == %{"foo" => "baz"}
+    conn = conn(:get, "/?f=g", a: "b", c: [d: "e"])
+    assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+    assert conn.params == %{"a" => "b", "c" => %{"d" => "e"}, "f" => "g"}
+
+    conn = conn(:post, "/?foo=bar", %{foo: "baz", answer: 42})
+    assert conn.body_params == %{"foo" => "baz", "answer" => 42}
+    assert conn.params == %{"foo" => "baz", "answer" => 42}
 
     conn = conn(:post, "/?foo=bar", %{biz: "baz"})
     assert conn.body_params == %{"biz" => "baz"}
@@ -56,8 +61,17 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert conn.path_info == []
   end
 
-  test "custom params sets content-type to multipart/mixed when content-type is not set" do
+  test "custom params sets no content-type for GET/HEAD requests" do
+    conn = conn(:head, "/")
+    assert conn.req_headers == []
+    conn = conn(:get, "/")
+    assert conn.req_headers == []
     conn = conn(:get, "/", foo: "bar")
+    assert conn.req_headers == []
+  end
+
+  test "custom params sets content-type to multipart/mixed when content-type is not set" do
+    conn = conn(:post, "/", foo: "bar")
     assert conn.req_headers == [{"content-type", "multipart/mixed; boundary=plug_conn_test"}]
   end
 


### PR DESCRIPTION
Related to phoenixframework/phoenix#3605

## Goals

1. Provide better real-world defaults for custom params in the test adapter
2. Minimize potential compatibility issues

## The problem

Let's say I have a page containing a list of paginated posts.
I want to write a test that says I can get to page 2 of my
posts, so I write the following in a test:

```elixir
conn = conn(:get, "/posts", page: 2)
```

and then in a handler somewhere, I match on that value:

```elixir
def call(%{params: %{page: page}} = conn, _) when is_integer(page) do
  ...find posts by page...
end
```

At the point, the tests will pass, but they will fail in
production, since the query param values will all be strings.

## Backwards compatibility

The current behavior of the test adapter is to treat all
custom params as `body_params`. This has the knock-on effect
of adding a `multipart/mixed` content-type header to the
request when one is not already set.

[RFC 7230 Section 3.3](https://tools.ietf.org/html/rfc7230#section-3.3) states:

> The presence of a message body in a request is signaled by a
Content-Length or Transfer-Encoding header field.  Request message
framing is independent of method semantics, even if the method does
not define any use for a message body.

Rather than require a content-length or transfer-encoding
header to parse custom params as a body, a change which would
likely break a majority of tests in the wild, these changes
aim to provide sensible default behavior for custom params,
in accordance with the HTTP method in use.

## Changes to behavior for GET/HEAD requests:

GET/HEAD request params are _fully stringified_:

```elixir
iex> conn(:get, "/posts", page: 2)
iex> conn.params
%{"page" => "2"}
```

they are **not** fetched as `body_params`:

```elixir
iex> conn.body_params
%Plug.Conn.Unfetched(aspect: :body_params)
```

and finally, no content-type is derived for these requests:

```elixir
iex> conn.req_headers
[]
```

**All other behavior remains the same**. For instance, binary
values will still be treated as the request body, and
_structs and functions will continue to be passed through unchanged_.
This is to preserve as much backwards compatibility as
possible while still improving developer experience in the
simple case.