### PR TITLE
Same site cookies

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1445,8 +1445,8 @@ defmodule Plug.Conn do
       non-standard cookie attributes.
     * `:signed` - when true, signs the cookie
     * `:encrypted` - when true, encrypts the cookie
-    * `:same_site` - apply the SameSite attribute to the cookie. Is only applied
-      if set to either `:lax`, `:strict` or `:none`
+    * `:same_site` - apply the SameSite attribute to the cookie. The attribute is 
+      only applied if `:same_site` is set to either `:lax`, `:strict` or `:none`
 
   """
   @spec put_resp_cookie(t, binary, any(), Keyword.t()) :: t

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1445,6 +1445,8 @@ defmodule Plug.Conn do
       non-standard cookie attributes.
     * `:signed` - when true, signs the cookie
     * `:encrypted` - when true, encrypts the cookie
+    * `:same_site` - apply the SameSite attribute to the cookie. Is only applied
+      if set to either `:lax`, `:strict` or `:none`
 
   """
   @spec put_resp_cookie(t, binary, any(), Keyword.t()) :: t

--- a/lib/plug/conn/cookies.ex
+++ b/lib/plug/conn/cookies.ex
@@ -61,6 +61,7 @@ defmodule Plug.Conn.Cookies do
       emit_if(opts[:max_age], &encode_max_age(&1, opts)),
       emit_if(Map.get(opts, :secure, false), "; secure"),
       emit_if(Map.get(opts, :http_only, true), "; HttpOnly"),
+      emit_if(Map.get(opts, :same_site, nil), &same_site/1),
       emit_if(opts[:extra], &["; ", &1])
     ])
   end
@@ -70,6 +71,10 @@ defmodule Plug.Conn.Cookies do
     time = add_seconds(time, max_age)
     ["; expires=", rfc2822(time), "; max-age=", Integer.to_string(max_age)]
   end
+
+  defp same_site(:lax), do: "; SameSite=Lax"
+  defp same_site(:strict), do: "; SameSite=Strict"
+  defp same_site(:none), do: "; SameSite=None"
 
   defp emit_if(value, fun_or_string) do
     cond do

--- a/lib/plug/session.ex
+++ b/lib/plug/session.ex
@@ -27,6 +27,7 @@ defmodule Plug.Session do
     * `:path` - see `Plug.Conn.put_resp_cookie/4`;
     * `:secure` - see `Plug.Conn.put_resp_cookie/4`;
     * `:http_only` - see `Plug.Conn.put_resp_cookie/4`;
+    * `:same_site` - see `Plug.Conn.put_resp_cookie/4`;
     * `:extra` - see `Plug.Conn.put_resp_cookie/4`;
 
   Additional options can be given to the session store, see the store's
@@ -40,7 +41,7 @@ defmodule Plug.Session do
   alias Plug.Conn
   @behaviour Plug
 
-  @cookie_opts [:domain, :max_age, :path, :secure, :http_only, :extra]
+  @cookie_opts [:domain, :max_age, :path, :secure, :http_only, :extra, :same_site]
 
   def init(opts) do
     store = Plug.Session.Store.get(Keyword.fetch!(opts, :store))

--- a/test/plug/conn/cookies_test.exs
+++ b/test/plug/conn/cookies_test.exs
@@ -56,15 +56,18 @@ defmodule Plug.Conn.CookiesTest do
   end
 
   test "encodes with :same_site option :lax" do
-    assert encode("foo", %{value: "bar", same_site: :lax}) == "foo=bar; path=/; HttpOnly; SameSite=Lax"
+    assert encode("foo", %{value: "bar", same_site: :lax}) ==
+             "foo=bar; path=/; HttpOnly; SameSite=Lax"
   end
 
   test "encodes with :same_site option :strict" do
-    assert encode("foo", %{value: "bar", same_site: :strict}) == "foo=bar; path=/; HttpOnly; SameSite=Strict"
+    assert encode("foo", %{value: "bar", same_site: :strict}) ==
+             "foo=bar; path=/; HttpOnly; SameSite=Strict"
   end
 
   test "encodes with :same_site option :none" do
-    assert encode("foo", %{value: "bar", same_site: :none}) == "foo=bar; path=/; HttpOnly; SameSite=None"
+    assert encode("foo", %{value: "bar", same_site: :none}) ==
+             "foo=bar; path=/; HttpOnly; SameSite=None"
   end
 
   test "encodes with :http_only option, which defaults to true" do

--- a/test/plug/conn/cookies_test.exs
+++ b/test/plug/conn/cookies_test.exs
@@ -51,6 +51,22 @@ defmodule Plug.Conn.CookiesTest do
     assert encode("foo", %{value: "bar", secure: true}) == "foo=bar; path=/; secure; HttpOnly"
   end
 
+  test "encodes without :same_site option if not set" do
+    assert encode("foo", %{value: "bar"}) == "foo=bar; path=/; HttpOnly"
+  end
+
+  test "encodes with :same_site option :lax" do
+    assert encode("foo", %{value: "bar", same_site: :lax}) == "foo=bar; path=/; HttpOnly; SameSite=Lax"
+  end
+
+  test "encodes with :same_site option :strict" do
+    assert encode("foo", %{value: "bar", same_site: :strict}) == "foo=bar; path=/; HttpOnly; SameSite=Strict"
+  end
+
+  test "encodes with :same_site option :none" do
+    assert encode("foo", %{value: "bar", same_site: :none}) == "foo=bar; path=/; HttpOnly; SameSite=None"
+  end
+
   test "encodes with :http_only option, which defaults to true" do
     assert encode("foo", %{value: "bar", http_only: false}) == "foo=bar; path=/"
   end


### PR DESCRIPTION
Closes #926 

Implements support for SameSite cookies in Plug. 

The default is not to include the `SameSite` attribute if not explicitly specified. 

We could consider making the default `SameSite=Lax`, however that could be a breaking change for many users. As mentioned in the issue above, some browsers are beginning to treat the absence of the `SameSite` attribute as `SameSite=Lax`.

I have tested the PR in a Phoenix project in Firefox 75.0 and Chrome 81.

Please let me know of any changes needed.