### PR TITLE
Support SameSite cookies with string values

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1445,6 +1445,8 @@ defmodule Plug.Conn do
       non-standard cookie attributes.
     * `:signed` - when true, signs the cookie
     * `:encrypted` - when true, encrypts the cookie
+    * `:same_site` - set the cookie SameSite attribute to a string value.
+      If no string value is set, the attribute is omitted.
 
   """
   @spec put_resp_cookie(t, binary, any(), Keyword.t()) :: t

--- a/lib/plug/conn/cookies.ex
+++ b/lib/plug/conn/cookies.ex
@@ -61,6 +61,7 @@ defmodule Plug.Conn.Cookies do
       emit_if(opts[:max_age], &encode_max_age(&1, opts)),
       emit_if(Map.get(opts, :secure, false), "; secure"),
       emit_if(Map.get(opts, :http_only, true), "; HttpOnly"),
+      emit_if(Map.get(opts, :same_site, nil), &encode_same_site/1),
       emit_if(opts[:extra], &["; ", &1])
     ])
   end
@@ -70,6 +71,8 @@ defmodule Plug.Conn.Cookies do
     time = add_seconds(time, max_age)
     ["; expires=", rfc2822(time), "; max-age=", Integer.to_string(max_age)]
   end
+
+  defp encode_same_site(value) when is_binary(value), do: "; SameSite=#{value}"
 
   defp emit_if(value, fun_or_string) do
     cond do

--- a/lib/plug/session.ex
+++ b/lib/plug/session.ex
@@ -27,6 +27,7 @@ defmodule Plug.Session do
     * `:path` - see `Plug.Conn.put_resp_cookie/4`;
     * `:secure` - see `Plug.Conn.put_resp_cookie/4`;
     * `:http_only` - see `Plug.Conn.put_resp_cookie/4`;
+    * `:same_site` - see `Plug.Conn.put_resp_cookie/4`;
     * `:extra` - see `Plug.Conn.put_resp_cookie/4`;
 
   Additional options can be given to the session store, see the store's
@@ -40,7 +41,7 @@ defmodule Plug.Session do
   alias Plug.Conn
   @behaviour Plug
 
-  @cookie_opts [:domain, :max_age, :path, :secure, :http_only, :extra]
+  @cookie_opts [:domain, :max_age, :path, :secure, :http_only, :extra, :same_site]
 
   def init(opts) do
     store = Plug.Session.Store.get(Keyword.fetch!(opts, :store))

--- a/test/plug/conn/cookies_test.exs
+++ b/test/plug/conn/cookies_test.exs
@@ -51,6 +51,25 @@ defmodule Plug.Conn.CookiesTest do
     assert encode("foo", %{value: "bar", secure: true}) == "foo=bar; path=/; secure; HttpOnly"
   end
 
+  test "encodes without :same_site option if not set" do
+    assert encode("foo", %{value: "bar"}) == "foo=bar; path=/; HttpOnly"
+  end
+
+  test "encodes with :same_site option :lax" do
+    assert encode("foo", %{value: "bar", same_site: "Lax"}) ==
+             "foo=bar; path=/; HttpOnly; SameSite=Lax"
+  end
+
+  test "encodes with :same_site option :strict" do
+    assert encode("foo", %{value: "bar", same_site: "Strict"}) ==
+             "foo=bar; path=/; HttpOnly; SameSite=Strict"
+  end
+
+  test "encodes with :same_site option :none" do
+    assert encode("foo", %{value: "bar", same_site: "None"}) ==
+             "foo=bar; path=/; HttpOnly; SameSite=None"
+  end
+
   test "encodes with :http_only option, which defaults to true" do
     assert encode("foo", %{value: "bar", http_only: false}) == "foo=bar; path=/"
   end


### PR DESCRIPTION
Closes #926 

Implements support for SameSite cookies in Plug with string values as agreed in #926.

The default is not to include the `SameSite` attribute if not explicitly specified. 

I have tested the PR in a Phoenix project in Firefox 75.0.
Please let me know of any changes needed.