### PR TITLE
Adding option to disable uft-8 validation uri

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -984,7 +984,13 @@ defmodule Plug.Conn do
         plug_status: 414
     end
 
-    query_params = Plug.Conn.Query.decode(query_string, %{}, Plug.Conn.InvalidQueryError)
+    query_params =
+      Plug.Conn.Query.decode(
+        query_string,
+        %{},
+        Plug.Conn.InvalidQueryError,
+        Keyword.get(opts, :validate_utf8, true)
+      )
 
     case params do
       %Unfetched{} -> %{conn | query_params: query_params, params: query_params}

--- a/lib/plug/conn/query.ex
+++ b/lib/plug/conn/query.ex
@@ -59,36 +59,46 @@ defmodule Plug.Conn.Query do
   The binary is assumed to be encoded in "x-www-form-urlencoded" format.
   The format is decoded and then validated for proper UTF-8 encoding.
   """
-  def decode(query, initial \\ %{}, invalid_exception \\ Plug.Conn.InvalidQueryError)
+  def decode(
+        query,
+        initial \\ %{},
+        invalid_exception \\ Plug.Conn.InvalidQueryError,
+        validate_utf8 \\ true
+      )
 
-  def decode("", initial, _invalid_exception) do
+  def decode("", initial, _invalid_exception, _validate_utf8) do
     initial
   end
 
-  def decode(query, initial, invalid_exception) do
+  def decode(query, initial, invalid_exception, validate_utf8) do
     parts = :binary.split(query, "&", [:global])
 
-    Enum.reduce(Enum.reverse(parts), initial, &decode_www_pair(&1, &2, invalid_exception))
+    Enum.reduce(
+      Enum.reverse(parts),
+      initial,
+      &decode_www_pair(&1, &2, invalid_exception, validate_utf8)
+    )
   end
 
-  defp decode_www_pair("", acc, _invalid_exception) do
+  defp decode_www_pair("", acc, _invalid_exception, _validate_utf8) do
     acc
   end
 
-  defp decode_www_pair(binary, acc, invalid_exception) do
+  defp decode_www_pair(binary, acc, invalid_exception, validate_utf8) do
     current =
       case :binary.split(binary, "=") do
         [key, value] ->
-          {decode_www_form(key, invalid_exception), decode_www_form(value, invalid_exception)}
+          {decode_www_form(key, invalid_exception, validate_utf8),
+           decode_www_form(value, invalid_exception, validate_utf8)}
 
         [key] ->
-          {decode_www_form(key, invalid_exception), nil}
+          {decode_www_form(key, invalid_exception, validate_utf8), nil}
       end
 
     decode_pair(current, acc)
   end
 
-  defp decode_www_form(value, invalid_exception) do
+  defp decode_www_form(value, invalid_exception, validate_utf8) do
     try do
       URI.decode_www_form(value)
     rescue
@@ -96,7 +106,10 @@ defmodule Plug.Conn.Query do
         raise invalid_exception, "invalid urlencoded params, got #{value}"
     else
       binary ->
-        Plug.Conn.Utils.validate_utf8!(binary, invalid_exception, "urlencoded params")
+        if validate_utf8 do
+          Plug.Conn.Utils.validate_utf8!(binary, invalid_exception, "urlencoded params")
+        end
+
         binary
     end
   end

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -335,7 +335,7 @@ defmodule Plug.ParsersTest do
     end
   end
 
-  test "do not raise when url contains invalid utf-8 char if validate_utf8 option is set to false" do
+  test "does not raise when url contains invalid utf-8 and validate_utf8 is false" do
     conn(:post, "/foo", "a=" <> <<139>>)
     |> parse(validate_utf8: false)
   end

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -335,6 +335,11 @@ defmodule Plug.ParsersTest do
     end
   end
 
+  test "do not raise when url contains invalid utf-8 char if validate_utf8 option is set to false" do
+    conn(:post, "/foo", "a=" <> <<139>>)
+    |> parse(validate_utf8: false)
+  end
+
   test "raises on too large bodies with root option" do
     exception =
       assert_raise Plug.Parsers.RequestTooLargeError, ~r/the request is too large/, fn ->


### PR DESCRIPTION
Binary can be passed in a uri by putting a percent char in from of a byte hex
representation.

Forcing the utf8 validation of uri forbids the passing of arbitrary
binary in a url, thus it disallow the use of plug in certain situation.

Fixing issue #925