### PR TITLE
Documentation error.  Results in /2 instead of /1 function all.

### DIFF
--- a/lib/plug/basic_auth.ex
+++ b/lib/plug/basic_auth.ex
@@ -47,7 +47,7 @@ defmodule Plug.BasicAuth do
              %User{} = user <- MyApp.Accounts.find_by_username_and_password(user, pass) do
           assign(conn, :current_user, user)
         else
-          _ -> Plug.BasicAuth.request_basic_auth(conn) |> halt()
+          _ -> conn |> Plug.BasicAuth.request_basic_auth() |> halt()
         end
       end
 

--- a/lib/plug/basic_auth.ex
+++ b/lib/plug/basic_auth.ex
@@ -47,7 +47,7 @@ defmodule Plug.BasicAuth do
              %User{} = user <- MyApp.Accounts.find_by_username_and_password(user, pass) do
           assign(conn, :current_user, user)
         else
-          _ -> conn |> Plug.BasicAuth.request_basic_auth(conn) |> halt()
+          _ -> Plug.BasicAuth.request_basic_auth(conn) |> halt()
         end
       end
 


### PR DESCRIPTION
The docs suggest piping conn into request_basic_auth(conn) which will result in the call request_basic_auth(conn, conn).

Could have gone with conn |> request_basic_auth() or request_basic_auth(conn).

I went with the latter.

<3 thx.