### PR TITLE
docs(CHANGELOG): add a note about `actions` printing a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
   * [Plug.Parsers] Add option to skip utf8 validation
   * [Plug.Parsers] Make multipart support MFA for `:length` limit
   * [Plug.Static] Accept MFA for `:header` option
+  
+### Notes
+  * When implementing the `Plug.Exception` protocol, if the new `actions` function is not implemented, a warning will printed during compilation.
 
 ## v1.8.3 (2019-07-28)
 


### PR DESCRIPTION
https://github.com/elixir-plug/plug/pull/876 adds `actions` to `Plug.Exception`
however if actions are not present on a protocol implementation, a warning
will be printed during compilation. This change highlights this warning.