### PR TITLE
add router dispatch events to plug router like phoenix router

### DIFF
--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -253,12 +253,35 @@ defmodule Plug.Router do
 
       @doc false
       def dispatch(%Plug.Conn{} = conn, opts) do
-        {_path, fun} = Map.fetch!(conn.private, :plug_route)
+        metadata = %{conn: conn, path: path}
+        start = System.monotonic_time()
+        {path, fun} = Map.fetch!(conn.private, :plug_route)
+
+        :telemetry.execute(
+          [:plug, :router_dispatch, :start],
+          %{system_time: System.system_time()},
+          metadata
+        )
 
         try do
           fun.(conn, opts)
+        else
+          conn ->
+            duration = System.monotonic_time() - start
+            metadata = %{metadata | conn: conn}
+            :telemetry.execute([:plug, :router_dispatch, :stop], %{duration: duration}, metadata)
+            conn
         catch
           kind, reason ->
+            duration = System.monotonic_time() - start
+            metadata = %{kind: kind, error: reason, stacktrace: __STACKTRACE__}
+
+            :telemetry.execute(
+              [:plug, :router_dispatch, :exception],
+              %{duration: duration},
+              metadata
+            )
+
             Plug.Conn.WrapperError.reraise(conn, kind, reason, __STACKTRACE__)
         end
       end

--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -253,9 +253,9 @@ defmodule Plug.Router do
 
       @doc false
       def dispatch(%Plug.Conn{} = conn, opts) do
-        metadata = %{conn: conn, path: path}
         start = System.monotonic_time()
         {path, fun} = Map.fetch!(conn.private, :plug_route)
+        metadata = %{conn: conn, route: path}
 
         :telemetry.execute(
           [:plug, :router_dispatch, :start],

--- a/test/plug/router_test.exs
+++ b/test/plug/router_test.exs
@@ -1,3 +1,5 @@
+Application.ensure_all_started(:telemetry)
+
 defmodule Plug.RouterTest do
   defmodule Forward do
     use Plug.Router

--- a/test/plug/telemetry_test.exs
+++ b/test/plug/telemetry_test.exs
@@ -15,6 +15,23 @@ defmodule Plug.TelemetryTest do
     end
   end
 
+  defmodule MyRoutePlug do
+    use Plug.Router
+
+    plug :match
+    plug :dispatch
+
+    def call(conn, opts) do
+      super(conn, opts)
+    after
+      Process.put(:plug_forward_call, true)
+    end
+
+    get "/" do
+      resp(conn, 200, "Response")
+    end
+  end
+
   defmodule MyNoSendPlug do
     use Plug.Builder
 
@@ -40,13 +57,21 @@ defmodule Plug.TelemetryTest do
   setup do
     start_handler_id = {:start, :rand.uniform(100)}
     stop_handler_id = {:stop, :rand.uniform(100)}
+    start_router_id = {:start, :rand.uniform(100)}
+    stop_router_id = {:stop, :rand.uniform(100)}
 
     on_exit(fn ->
       :telemetry.detach(start_handler_id)
       :telemetry.detach(stop_handler_id)
+      :telemetry.detach(start_router_id)
+      :telemetry.detach(stop_router_id)
     end)
 
-    {:ok, start_handler: start_handler_id, stop_handler: stop_handler_id}
+    {:ok,
+     start_handler: start_handler_id,
+     stop_handler: stop_handler_id,
+     start_router: start_router_id,
+     stop_router: stop_router_id}
   end
 
   test "emits an event before the pipeline and before sending the response", %{
@@ -113,6 +138,19 @@ defmodule Plug.TelemetryTest do
 
     assert_received {:event, [:crashing, :pipeline, :start], _, _}
     refute_received {:event, [:crashing, :pipeline, :stop], _, _}
+  end
+
+  test "emit start and stop event when router dispatches", %{
+    start_router: start_router,
+    stop_router: stop_router
+  } do
+    attach(start_router, [:plug, :router_dispatch, :start])
+    attach(stop_router, [:plug, :router_dispatch, :stop])
+
+    MyRoutePlug.call(conn(:get, "/"), [])
+
+    assert_received {:event, [:plug, :router_dispatch, :start], _, _}
+    assert_received {:event, [:plug, :router_dispatch, :stop], _, _}
   end
 
   defp attach(handler_id, event) do


### PR DESCRIPTION
Telemetry events meant to match the behaviour of Phoenix's router.