### PR TITLE
Fixes visual bug for long assing string

### DIFF
--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -167,7 +167,7 @@
 
     .exception-info > .detail {
         margin-top: 1.3em;
-        white-space: pre;
+        white-space: pre-wrap;
     }
 
     /*


### PR DESCRIPTION
**Before**
![image](https://user-images.githubusercontent.com/4539062/81731907-eddae000-948f-11ea-85d2-7172bfcbdbec.png)

**After**
![image](https://user-images.githubusercontent.com/4539062/81731951-03500a00-9490-11ea-8e28-5daf08e4a8e8.png)

The issue is present on Firefox and Chrome ( on Ubuntu )
