### PR TITLE
Implement runtime_forward

### DIFF
--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -75,7 +75,7 @@ defmodule Plug do
   end
 
   @doc """
-  Forwards requests to another Plug at a new path.
+  Forwards requests to another Plug setting the connection to a trailing subpath of the request.
 
   The `path_info` on the forwarded connection will only include the trailing segments
   of the request path supplied to forward, while `conn.script_name` will

--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -327,47 +327,6 @@ defmodule Plug.Router do
     path
   end
 
-  @doc """
-  Forwards requests to another Plug with runtime arguments.
-
-  The `path_info` on the forwared connection will only include the trailing segments
-  of the request path supplied to `runtime_forward`, while `conn.script_name` will
-  retain the correct base path for e.g. url generation.
-
-  ## Example
-
-      defmodule TenantRouter do
-        def init(opts) do
-          %{
-            common_router: CommonRouter.init(opts[:common_router])
-            tenant_router: TenantRouter.init(opts[:tenant_router])
-          }
-        end
-
-        def call(conn, opts) do
-          # Normalize the following to all be served by a single router matching
-          # on `path`, even if the request paths are different.
-          # * http://service.some-company.com/*path
-          # * http://company.my-service.com/*path
-          # * http://www.my-service.com/company/*path
-          #
-          with :unmatched <- tenant_cname(conn),
-               :unmatched <- tenant_host(conn, allowed_root_host),
-               :unmatched <- tenant_path(conn) do
-            CommonRouter.call(conn, opts.common_router)
-          else
-            {:match, path} ->
-              Plug.Router.runtime_forward(conn, path, TenantRouter, opts.tenant_router)
-          end
-        end
-      end
-
-  """
-  @spec runtime_forward(Plug.Conn.t(), [String.t()], atom, Plug.opts()) :: Plug.Conn.t()
-  def runtime_forward(%Plug.Conn{} = conn, path, plug, opts \\ []) when is_list(path) do
-    Plug.Router.Utils.forward(conn, path, plug, opts)
-  end
-
   ## Match
 
   @doc """

--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -483,7 +483,7 @@ defmodule Plug.Router do
       # Delegate the matching to the match/3 macro along with the options
       # specified by Keyword.split/2.
       match path <> "/*glob", options do
-        Plug.Router.Utils.forward(
+        Plug.forward(
           var!(conn),
           var!(glob),
           @plug_forward_target,

--- a/lib/plug/router/utils.ex
+++ b/lib/plug/router/utils.ex
@@ -103,15 +103,10 @@ defmodule Plug.Router.Utils do
   @doc """
   Forwards requests to another Plug at a new path.
   """
-  def forward(%Plug.Conn{path_info: path, script_name: script} = conn, new_path, target, opts) do
-    {base, split_path} = Enum.split(path, length(path) - length(new_path))
-
-    conn = do_forward(target, %{conn | path_info: split_path, script_name: script ++ base}, opts)
-    %{conn | path_info: path, script_name: script}
+  @deprecated "Use Plug.forward/4 instead"
+  def forward(conn, new_path, target, opts) do
+    Plug.forward(conn, new_path, target, opts)
   end
-
-  defp do_forward({mod, fun}, conn, opts), do: apply(mod, fun, [conn, opts])
-  defp do_forward(mod, conn, opts), do: mod.call(conn, opts)
 
   @doc """
   Splits the given path into several segments.

--- a/lib/plug/router/utils.ex
+++ b/lib/plug/router/utils.ex
@@ -101,14 +101,6 @@ defmodule Plug.Router.Utils do
   end
 
   @doc """
-  Forwards requests to another Plug at a new path.
-  """
-  @deprecated "Use Plug.forward/4 instead"
-  def forward(conn, new_path, target, opts) do
-    Plug.forward(conn, new_path, target, opts)
-  end
-
-  @doc """
   Splits the given path into several segments.
   It ignores both leading and trailing slashes in the path.
 

--- a/test/plug/router_test.exs
+++ b/test/plug/router_test.exs
@@ -52,22 +52,6 @@ defmodule Plug.RouterTest do
     end
   end
 
-  defmodule RuntimeForward do
-    def init(opts) do
-      Forward.init(opts)
-    end
-
-    def call(conn, opts) do
-      case conn do
-        %{path_info: ["prefix" | rest]} ->
-          Plug.Router.runtime_forward(conn, rest, Forward, opts)
-
-        _ ->
-          Forward.call(conn, opts)
-      end
-    end
-  end
-
   defmodule Reforward do
     use Plug.Router
     use Plug.ErrorHandler
@@ -541,11 +525,6 @@ defmodule Plug.RouterTest do
 
     assert_received {:event, [:plug, :router_dispatch, :stop], %{duration: _},
                      %{route: "/", conn: %Plug.Conn{}, router: Sample}}
-  end
-
-  test "forward at runtime, allowing custom code to assert which segments to strip" do
-    conn = call(RuntimeForward, conn(:get, "/prefix/"))
-    assert conn.resp_body == "forwarded"
   end
 
   defp attach(handler_id, event) do

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -1,0 +1,43 @@
+defmodule PlugTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  defmodule Response do
+    use Plug.Router
+
+    plug :match
+    plug :dispatch
+
+    get "/*path" do
+      response = """
+      path: #{path}
+      script_name: #{Path.join(conn.script_name)}
+      path_info: #{Path.join(conn.path_info)}
+      """
+
+      resp(conn, 200, response)
+    end
+  end
+
+  defmodule Forward do
+    def init(opts) do
+      Forward.init(opts)
+    end
+
+    def call(conn, opts) do
+      case conn do
+        %{path_info: ["prefix" | rest]} ->
+          Plug.forward(conn, rest, Response, opts)
+
+        _ ->
+          Response.call(conn, opts)
+      end
+    end
+  end
+
+  test "forward can strip segments of the path affecting path matching for the called plug" do
+    conn = Forward.call(conn(:get, "/prefix/more/segments"), [])
+    assert conn.resp_body =~ "script_name: prefix"
+    assert conn.resp_body =~ "path_info: more/segments"
+  end
+end


### PR DESCRIPTION
In regards to #942 

I'm not yet sure on the example/docs. The "feature" of the function is that it allows users to normalize routes, which sit in multiple places of an application, but are meant to be handled exactly the same in terms of the forwarded to router. 