### PR TITLE
Populate `:query_string` when params are passed in.

### DIFF
--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -17,51 +17,49 @@ defmodule Plug.Adapters.Test.ConnTest do
   test "custom params" do
     conn = conn(:head, "/posts", page: 2)
     assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+    assert conn.query_string == "page=2"
     assert conn.params == %{"page" => "2"}
     assert conn.req_headers == []
 
     conn = conn(:get, "/", a: [b: 0, c: 5], d: [%{e: "f"}])
     assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+    assert conn.query_string == "a[b]=0&a[c]=5&d[][e]=f"
     assert conn.params == %{"a" => %{"b" => "0", "c" => "5"}, "d" => [%{"e" => "f"}]}
 
     conn = conn(:get, "/?foo=bar", %{foo: "baz"})
     assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+    assert conn.query_string == "foo=bar"
     assert conn.params == %{"foo" => "baz"}
 
     conn = conn(:get, "/?foo=bar", %{biz: "baz"})
     assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+    assert conn.query_string == "biz=baz&foo=bar"
     assert conn.params == %{"foo" => "bar", "biz" => "baz"}
 
     conn = conn(:get, "/?f=g", a: "b", c: [d: "e"])
     assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+    assert conn.query_string == "a=b&c[d]=e&f=g"
     assert conn.params == %{"a" => "b", "c" => %{"d" => "e"}, "f" => "g"}
+
+    conn = conn(:get, "/", %{})
+    assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+    assert conn.query_string == ""
+    assert conn.params == %{}
 
     conn = conn(:post, "/?foo=bar", %{foo: "baz", answer: 42})
     assert conn.body_params == %{"foo" => "baz", "answer" => 42}
+    assert conn.query_string == "foo=bar"
     assert conn.params == %{"foo" => "baz", "answer" => 42}
 
     conn = conn(:post, "/?foo=bar", %{biz: "baz"})
     assert conn.body_params == %{"biz" => "baz"}
+    assert conn.query_string == "foo=bar"
     assert conn.params == %{"foo" => "bar", "biz" => "baz"}
-  end
 
-  test "custom struct params" do
-    conn = conn(:get, "/", a: "b", file: %Plug.Upload{})
-
-    assert conn.params == %{
-             "a" => "b",
-             "file" => %Plug.Upload{content_type: nil, filename: nil, path: nil}
-           }
-
-    conn = conn(:get, "/", a: "b", file: %{__struct__: "Foo"})
-    assert conn.params == %{"a" => "b", "file" => %{"__struct__" => "Foo"}}
-  end
-
-  test "custom function params" do
-    conn = conn(:get, "/", action: fn -> "this is fine" end)
-
-    assert %{"action" => _action} = conn.params
-    assert conn.params["action"].() == "this is fine"
+    conn = conn(:post, "/", %{})
+    assert conn.body_params == %{}
+    assert conn.query_string == ""
+    assert conn.params == %{}
   end
 
   test "no body or params" do


### PR DESCRIPTION
As per changes from [this PR](https://github.com/elixir-plug/plug/pull/922), the semantics of passing in extra params has changed.

The first semantic change is that `:body_params` will no longer be populated when it's a `GET`/`HEAD` request.

The second semantic change is that all of these should be equivalent:

```elixir
conn(:get, "/endpoint?page=2")
conn(:get, "/endpoint", page: 2)
conn(:get, "/endpoint", page: "2")
conn(:get, "/endpoint", %{page: 2})
conn(:get, "/endpoint", %{page: "2"})
conn(:get, "/endpoint", %{"page" => 2})
conn(:get, "/endpoint", %{"page" => "2"})
```

However, as pointed out in [this issue](https://github.com/elixir-plug/plug/issues/941), there is a slight difference in behavior between:

```elixir
conn(:get, "/posts?page=2")
conn(:get, "/posts", page: 2)
```

In the former, `:query_params` are populated, but in the latter, it's not. This commit fixes that.

Fixes [this issue](https://github.com/elixir-plug/plug/issues/941)