### PR TITLE
Emit event when telemetry is loaded

### DIFF
--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -239,7 +239,8 @@ defmodule Plug.Router do
 
   ## Telemetry
 
-  The router emits the following telemetry events:
+  The router emits the following telemetry events when
+  [:telemetry](https://github.com/beam-telemetry/telemetry) is a project dependency:
 
     * `[:plug, :router_dispatch, :start]` - dispatched before dispatching to a matched route
       * Measurement: `%{system_time: System.system_time}`


### PR DESCRIPTION
The latest version of plug v1.10.1 makes `telemetry` required because of #934, which conflicts with the dependency definition in `mix.exs`.
One option would be to make `telemetry` required, another one would be to emit the event only when the module is available.
I don`t have a particular preference, but I found it would be fun to try the second.