### PR TITLE
Ability to read excluded host from env variable

### DIFF
--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -335,7 +335,7 @@ defmodule Plug.SSL do
     end
   end
 
-  defp excluded?(host, {mod, fun, args}), do: apply(mod, fun, [host|args])
+  defp excluded?(host, {mod, fun, args}), do: apply(mod, fun, [host | args])
   defp excluded?(host, list), do: :lists.member(host, list)
 
   defp rewrite_on(conn, [:x_forwarded_proto | rewrite_on]) do

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -66,15 +66,13 @@ defmodule Plug.SSL do
   the plug is checking whether to redirect host. Provided function needs
   to receive at least one argument (`host`).
 
-  For example, `config/prod.exs` of a Phoenix app can contain:
+  For example, you may define it as:
 
-      config :sample_app, SampleAppWeb.Endpoint,
-        force_ssl: [
-          rewrite_on: [:x_forwarded_proto],
-          exclude: {SampleAppWeb, :excluded_host?, []}
-        ]
+      plug Plug.SSL,
+        rewrite_on: [:x_forwarded_proto],
+        exclude: {__MODULE__, :excluded_host?, []}
 
-  and `lib/sample_app_web.ex`:
+  where:
 
       def excluded_host?(host) do
         # Custom logic
@@ -335,8 +333,8 @@ defmodule Plug.SSL do
     end
   end
 
+  defp excluded?(host, list) when is_list(list), do: :lists.member(host, list)
   defp excluded?(host, {mod, fun, args}), do: apply(mod, fun, [host | args])
-  defp excluded?(host, list), do: :lists.member(host, list)
 
   defp rewrite_on(conn, [:x_forwarded_proto | rewrite_on]) do
     conn

--- a/test/plug/ssl_test.exs
+++ b/test/plug/ssl_test.exs
@@ -103,8 +103,8 @@ defmodule Plug.SSLTest do
     end
   end
 
-  def excluded_hosts do
-    [System.get_env("EXCLUDED_HOST")]
+  def excluded_host?(host) do
+    host == System.get_env("EXCLUDED_HOST")
   end
 
   defp call(conn, opts \\ []) do
@@ -136,7 +136,7 @@ defmodule Plug.SSLTest do
 
       conn =
         conn(:get, "https://10.0.0.1/")
-        |> call(exclude: {__MODULE__, :excluded_hosts, []})
+        |> call(exclude: {__MODULE__, :excluded_host?, []})
 
       assert get_resp_header(conn, "strict-transport-security") == []
       refute conn.halted

--- a/test/plug/ssl_test.exs
+++ b/test/plug/ssl_test.exs
@@ -129,7 +129,11 @@ defmodule Plug.SSLTest do
 
     test "excludes tuple" do
       System.put_env("EXCLUDED_HOST", "10.0.0.1")
-      conn = call(conn(:get, "https://10.0.0.1/"), exclude: [{System, :get_env, ["EXCLUDED_HOST"]}])
+
+      conn =
+        conn(:get, "https://10.0.0.1/")
+        |> call(exclude: [{System, :get_env, ["EXCLUDED_HOST"]}])
+
       assert get_resp_header(conn, "strict-transport-security") == []
       refute conn.halted
     end

--- a/test/plug/ssl_test.exs
+++ b/test/plug/ssl_test.exs
@@ -127,6 +127,13 @@ defmodule Plug.SSLTest do
       refute conn.halted
     end
 
+    test "excludes tuple" do
+      System.put_env("EXCLUDED_HOST", "10.0.0.1")
+      conn = call(conn(:get, "https://10.0.0.1/"), exclude: [{System, :get_env, ["EXCLUDED_HOST"]}])
+      assert get_resp_header(conn, "strict-transport-security") == []
+      refute conn.halted
+    end
+
     test "when true" do
       conn = call(conn(:get, "https://example.com/"), hsts: true)
       assert get_resp_header(conn, "strict-transport-security") == ["max-age=31536000"]

--- a/test/plug/ssl_test.exs
+++ b/test/plug/ssl_test.exs
@@ -103,6 +103,10 @@ defmodule Plug.SSLTest do
     end
   end
 
+  def excluded_hosts do
+    [System.get_env("EXCLUDED_HOST")]
+  end
+
   defp call(conn, opts \\ []) do
     opts = Keyword.put_new(opts, :log, false)
     Plug.SSL.call(conn, Plug.SSL.init(opts))
@@ -132,7 +136,7 @@ defmodule Plug.SSLTest do
 
       conn =
         conn(:get, "https://10.0.0.1/")
-        |> call(exclude: [{System, :get_env, ["EXCLUDED_HOST"]}])
+        |> call(exclude: {__MODULE__, :excluded_hosts, []})
 
       assert get_resp_header(conn, "strict-transport-security") == []
       refute conn.halted


### PR DESCRIPTION
I want to setup HTTPS redirection on Kubernetes, but I need to let health check use HTTP.
I'm using Elixir release and I don't know pod IP before building code, therefore I need to read it from environment variable.

For example:
```
config :sample, SampleWeb.Endpoint,
  force_ssl: [rewrite_on: [:x_forwarded_proto], exclude: ["localhost", {System, :get_env, ["POD_IP"]}]]
```

This makes health check pass and redirects clients to HTTPS.