### PR TITLE
Fix doc for put_resp_cookie

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1398,7 +1398,7 @@ defmodule Plug.Conn do
   value can be any term.
 
   If the cookie not signed nor encrypted, then the value must be a binary.
-  Note the is not automatically escaped.  Therefore if you want to store
+  Note the value is not automatically escaped. Therefore if you want to store
   values with non-alphanumeric characters, you must either sign or encrypt
   the cookie or consider explicitly escaping the cookie value by using a
   function such as `Base.encode64(value, padding: false)` when writing and


### PR DESCRIPTION
The word 'value' was missing.