### PR TITLE
Allow the limit-calculating function to be stateful w/respect to conn

### DIFF
--- a/lib/plug/parsers/multipart.ex
+++ b/lib/plug/parsers/multipart.ex
@@ -12,10 +12,17 @@ defmodule Plug.Parsers.MULTIPART do
       passing an MFA (`{module, function, args}`) which will be evaluated
       on every request to determine the value.
 
+      Passing {:stateful, module, function, args} as the length argument
+      results in the conn object for the request being passed as the first
+      parameter (before the predefined args), allowing the length to be
+      determined statefully with respect to the conn object.
+
     * `:read_length` - sets the amount of bytes to read at one time from the
       underlying socket to fill the chunk, defaults to 1_000_000 bytes
+
     * `:read_timeout` - sets the timeout for each socket read, defaults to
       15_000ms
+
 
   So by default, `Plug.Parsers` will read 1_000_000 bytes at a time from the
   socket with an overall limit of 8_000_000 bytes.
@@ -72,6 +79,10 @@ defmodule Plug.Parsers.MULTIPART do
   end
 
   ## Multipart
+  defp parse_multipart(conn, {{:stateful, module, fun, args}, header_opts, opts}) do
+    limit = apply(module, fun, [conn | args])
+    parse_multipart(conn, {limit, header_opts, opts})
+  end
 
   defp parse_multipart(conn, {{module, fun, args}, header_opts, opts}) do
     limit = apply(module, fun, args)

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -222,14 +222,29 @@ defmodule Plug.ParsersTest do
       def get() do
         Agent.get(:multipart_length, & &1)
       end
+
+      def stateful_get(%Plug.Conn{}, 10) do
+        Agent.get(:multipart_length, & &1)
+      end
     end
 
     opts = Plug.Parsers.init(parsers: [{:multipart, length: {LengthGetter, :get, []}}])
+
+    stateful_opts =
+      Plug.Parsers.init(
+        parsers: [{:multipart, length: {:stateful, LengthGetter, :stateful_get, [10]}}]
+      )
 
     assert_raise Plug.Parsers.RequestTooLargeError, fn ->
       conn(:post, "/", multipart)
       |> put_req_header("content-type", "multipart/mixed; boundary=----w58EW1cEpjzydSCq")
       |> Plug.Parsers.call(opts)
+    end
+
+    assert_raise Plug.Parsers.RequestTooLargeError, fn ->
+      conn(:post, "/", multipart)
+      |> put_req_header("content-type", "multipart/mixed; boundary=----w58EW1cEpjzydSCq")
+      |> Plug.Parsers.call(stateful_opts)
     end
 
     Agent.update(:multipart_length, fn _ -> 10_000 end)
@@ -238,6 +253,13 @@ defmodule Plug.ParsersTest do
       conn(:post, "/", multipart)
       |> put_req_header("content-type", "multipart/mixed; boundary=----w58EW1cEpjzydSCq")
       |> Plug.Parsers.call(opts)
+
+    assert params["name"] == "hello"
+
+    %{params: params} =
+      conn(:post, "/", multipart)
+      |> put_req_header("content-type", "multipart/mixed; boundary=----w58EW1cEpjzydSCq")
+      |> Plug.Parsers.call(stateful_opts)
 
     assert params["name"] == "hello"
   end


### PR DESCRIPTION
By adding a :stateful tag to the MFA tuple passed to the limit option of the multipart parser, the conn is passed in to the function. This allows, for instance, the upload limit to be adjusted dynamically based on user session details or other data in the conn.

This is fully backwards-compatible and unit tests have been added for this feature extension..

Note: to access sessions for use in the limit calculating function, Plug.Session needs to appear before Plug.Parsers in the plug chain. Currently, Phoenix places this after Plug.Parsers, Plug.MethodOverride, and Plug.Head. I have been testing with Plug.Session before Plug.Parsers and have yet to see any issues, but this testing has not been exhaustive. Without sessions, the limit calculating function still has access to other details in the conn object, of course.