### PR TITLE
Bug: Error when sent empty body

### DIFF
--- a/test/plug/csrf_protection_test.exs
+++ b/test/plug/csrf_protection_test.exs
@@ -120,6 +120,18 @@ defmodule Plug.CSRFProtectionTest do
     end
   end
 
+  test "raise error for missing authenticity token with empty body" do
+    assert_raise InvalidCSRFTokenError, fn ->
+      call(conn(:post, "/", ""))
+    end
+
+    assert_raise InvalidCSRFTokenError, fn ->
+      conn(:post, "/", "")
+      |> put_req_header("x-csrf-token", "foo")
+      |> call()
+    end
+  end
+
   test "raise error for invalid authenticity token in params" do
     old_conn = call(conn(:get, "/"))
 


### PR DESCRIPTION
When a request arrives with an empty body and an invalid or missing CSRF token, I'd like `Plug.CSRFProtection` to raise a `InvalidCSRFTokenError`. Right now, it causes an `ArgumentError` due to some issue with unfetched params. I'm not sure exactly how to fix the problem, but I've written a failing test to demonstrate the problem.