### PR TITLE
Include LICENSE file when publishing to hex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule Plug.MixProject do
       licenses: ["Apache-2.0"],
       maintainers: ["Gary Rennie", "José Valim"],
       links: %{"GitHub" => "https://github.com/elixir-plug/plug"},
-      files: ["lib", "mix.exs", "README.md", "CHANGELOG.md", "src", ".formatter.exs"]
+      files: ["lib", "mix.exs", "README.md", "CHANGELOG.md", "LICENSE", "src", ".formatter.exs"]
     }
   end
 


### PR DESCRIPTION
Makes it easier for tools to parse license information and generate 3rd-party license notices files.