### PR TITLE
Change default cache-control header to no-store

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -55,7 +55,7 @@ defmodule Plug.Conn do
       charset used defaults to "utf-8".
     * `resp_cookies` - the response cookies with their name and options
     * `resp_headers` - the response headers as a list of tuples, by default `cache-control`
-      is set to `"max-age=0, private, must-revalidate"`. Note, response headers
+      is set to `"no-store"`. Note, response headers
       are expected to have lowercase keys.
     * `status` - the response status
 
@@ -199,7 +199,7 @@ defmodule Plug.Conn do
             request_path: "",
             resp_body: nil,
             resp_cookies: %{},
-            resp_headers: [{"cache-control", "max-age=0, private, must-revalidate"}],
+            resp_headers: [{"cache-control", "no-store"}],
             scheme: :http,
             script_name: [],
             secret_key_base: nil,

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -175,7 +175,7 @@ defmodule Plug.ConnTest do
   test "status, resp_headers and resp_body" do
     conn = conn(:get, "/foo")
     assert conn.status == nil
-    assert conn.resp_headers == [{"cache-control", "max-age=0, private, must-revalidate"}]
+    assert conn.resp_headers == [{"cache-control", "no-store"}]
     assert conn.resp_body == nil
   end
 

--- a/test/plug/static_test.exs
+++ b/test/plug/static_test.exs
@@ -163,7 +163,7 @@ defmodule Plug.StaticTest do
     conn = Plug.Static.call(conn(:get, "/public/fixtures/static.txt"), Plug.Static.init(opts))
 
     assert conn.status == 200
-    assert get_resp_header(conn, "cache-control") == ["max-age=0, private, must-revalidate"]
+    assert get_resp_header(conn, "cache-control") == ["no-store"]
     assert get_resp_header(conn, "etag") == []
     assert get_resp_header(conn, "x-custom") == ["x-value"]
   end
@@ -521,7 +521,7 @@ defmodule Plug.StaticTest do
       assert conn.resp_body == "HE"
       assert get_resp_header(conn, "accept-ranges") == ["bytes"]
       assert get_resp_header(conn, "content-range") == ["bytes 0-1/5"]
-      assert get_resp_header(conn, "cache-control") == ["max-age=0, private, must-revalidate"]
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
       assert get_resp_header(conn, "etag") == []
       assert get_resp_header(conn, "x-custom") == ["x-value"]
     end


### PR DESCRIPTION
Hi!

While looking into the results of a security scan, I noticed that [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Examples) currently suggests using `no-store` instead of setting all three `max-age, private and must-revalidate`. I'll be the first to admit that I don't fully understand all of the repercussions of this change, but I couldn't find anything that suggests it would not be a safe default.

Looking forward to your feedback; thanks!