### PR TITLE
Use explicit Logger macros to allow for compile-time purging

### DIFF
--- a/lib/plug/logger.ex
+++ b/lib/plug/logger.ex
@@ -24,14 +24,14 @@ defmodule Plug.Logger do
   end
 
   def call(conn, level) do
-    Logger.log(level, fn ->
+    log(level, fn ->
       [conn.method, ?\s, conn.request_path]
     end)
 
     start = System.monotonic_time()
 
     Conn.register_before_send(conn, fn conn ->
-      Logger.log(level, fn ->
+      log(level, fn ->
         stop = System.monotonic_time()
         diff = System.convert_time_unit(stop - start, :native, :microsecond)
         status = Integer.to_string(conn.status)
@@ -42,6 +42,11 @@ defmodule Plug.Logger do
       conn
     end)
   end
+
+  defp log(:debug, chardata_or_fun), do: Logger.debug(chardata_or_fun)
+  defp log(:info, chardata_or_fun), do: Logger.info(chardata_or_fun)
+  defp log(:warn, chardata_or_fun), do: Logger.warn(chardata_or_fun)
+  defp log(:error, chardata_or_fun), do: Logger.error(chardata_or_fun)
 
   defp formatted_diff(diff) when diff > 1000, do: [diff |> div(1000) |> Integer.to_string(), "ms"]
   defp formatted_diff(diff), do: [Integer.to_string(diff), "µs"]


### PR DESCRIPTION
According to Logger Documentation, this is the preferred approach. https://hexdocs.pm/logger/Logger.html#log/3