### PR TITLE
Use defoverridable Behaviour

### DIFF
--- a/lib/plug/builder.ex
+++ b/lib/plug/builder.ex
@@ -115,7 +115,7 @@ defmodule Plug.Builder do
         plug_builder_call(conn, opts)
       end
 
-      defoverridable init: 1, call: 2
+      defoverridable Plug
 
       import Plug.Conn
       import Plug.Builder, only: [plug: 1, plug: 2, builder_opts: 0]


### PR DESCRIPTION
As per https://hexdocs.pm/elixir/Kernel.html#defoverridable/1-example-1 and https://elixirforum.com/t/behaviours-defoverridable-and-implementations/3338, `defoverride Behaviourname` is preferred instead of `defoverride func1, func2`