### PR TITLE
Fix compiler warning in Elixir 1.11

### DIFF
--- a/lib/plug/conn/wrapper_error.ex
+++ b/lib/plug/conn/wrapper_error.ex
@@ -20,7 +20,7 @@ defmodule Plug.Conn.WrapperError do
 
   @deprecated "Use reraise/1 or reraise/4 instead"
   def reraise(conn, kind, reason) do
-    reraise(conn, kind, reason, System.stacktrace())
+    reraise(conn, kind, reason, __STACKTRACE__)
   end
 
   def reraise(_conn, :error, %__MODULE__{stack: stack} = reason, _stack) do


### PR DESCRIPTION
Elixir 1.11 deprecates `System.stacktrace/0`, so this generates a compiler warning in projects using Elixir 1.11 with Plug.

Since Plug already depends on at least Elixir 1.7 (when `__STACKTRACE__` was introduced), that requirement doesn't need to be updated.