### PR TITLE
RemoveStacktraceDeprecations

### DIFF
--- a/lib/plug/conn/wrapper_error.ex
+++ b/lib/plug/conn/wrapper_error.ex
@@ -20,7 +20,7 @@ defmodule Plug.Conn.WrapperError do
 
   @deprecated "Use reraise/1 or reraise/4 instead"
   def reraise(conn, kind, reason) do
-    reraise(conn, kind, reason, System.stacktrace())
+    reraise(conn, kind, reason, __STACKTRACE__)
   end
 
   def reraise(_conn, :error, %__MODULE__{stack: stack} = reason, _stack) do


### PR DESCRIPTION
Replacing instance of System.stacktrace() with __STACKTRACE__ as per compiler warnings in Elixir 1.11