### PR TITLE
Allow transfer of ownership v2

### DIFF
--- a/lib/plug/upload.ex
+++ b/lib/plug/upload.ex
@@ -60,25 +60,83 @@ defmodule Plug.Upload do
     end
   end
 
+  @doc """
+  Assign ownership of the given upload file to another process.
+
+  Useful if you want to do some work on an uploaded file in another process
+  since it means that the file will survive the end of the request.
+  """
+  @spec give_away(t | binary, pid, pid) :: :ok | {:error, binary}
+  def give_away(upload, to_pid, from_pid \\ self())
+
+  def give_away(%__MODULE__{path: path}, to_pid, from_pid) do
+    give_away(path, to_pid, from_pid)
+  end
+
+  def give_away(path, to_pid, from_pid)
+      when is_binary(path) and is_pid(to_pid) and is_pid(from_pid) do
+    with [{^from_pid, _tmp}] <- :ets.lookup(@dir_table, from_pid),
+         true <- is_path_owner?(from_pid, path) do
+      case :ets.lookup(@dir_table, to_pid) do
+        [{^to_pid, _tmp}] ->
+          :ets.insert(@path_table, {to_pid, path})
+          :ets.delete_object(@path_table, {from_pid, path})
+
+          :ok
+
+        [] ->
+          server = plug_server()
+
+          with {:ok, tmps} <- GenServer.call(server, :roots),
+               {:ok, tmp} <- generate_tmp_dir(tmps),
+               :ok <- GenServer.call(server, {:give_away, to_pid, tmp, path}) do
+            :ets.delete_object(@path_table, {from_pid, path})
+            :ok
+          else
+            {:no_tmp, _tmps} ->
+              # would be pretty extraordinary to fail at this point since we've already
+              # definitely created an upload
+              raise Plug.UploadError,
+                    "could not create a tmp directory to store uploads. " <>
+                      "Set PLUG_TMPDIR to a directory with write permission"
+
+            error ->
+              error
+          end
+      end
+    else
+      _ ->
+        {:error, "PID #{inspect(from_pid)} does not own path #{inspect(path)}"}
+    end
+  end
+
   defp ensure_tmp() do
     pid = self()
-    server = plug_server()
 
     case :ets.lookup(@dir_table, pid) do
       [{^pid, tmp}] ->
         {:ok, tmp}
 
       [] ->
-        {:ok, tmps} = GenServer.call(server, {:monitor, pid})
-        {mega, _, _} = :os.timestamp()
-        subdir = "/plug-" <> i(mega)
+        server = plug_server()
 
-        if tmp = Enum.find_value(tmps, &make_tmp_dir(&1 <> subdir)) do
+        {:ok, tmps} = GenServer.call(server, {:monitor, pid})
+
+        with {:ok, tmp} <- generate_tmp_dir(tmps) do
           true = :ets.insert_new(@dir_table, {pid, tmp})
           {:ok, tmp}
-        else
-          {:no_tmp, tmps}
         end
+    end
+  end
+
+  defp generate_tmp_dir(tmp_roots) do
+    {mega, _, _} = :os.timestamp()
+    subdir = "/plug-" <> i(mega)
+
+    if tmp = Enum.find_value(tmp_roots, &make_tmp_dir(&1 <> subdir)) do
+      {:ok, tmp}
+    else
+      {:no_tmp, tmp_roots}
     end
   end
 
@@ -111,6 +169,12 @@ defmodule Plug.Upload do
     rand = :rand.uniform(999_999_999_999_999)
     scheduler_id = :erlang.system_info(:scheduler_id)
     tmp <> "/" <> prefix <> "-" <> i(sec) <> "-" <> i(rand) <> "-" <> i(scheduler_id)
+  end
+
+  defp is_path_owner?(pid, path) do
+    owned_paths = :ets.lookup(@path_table, pid)
+
+    Enum.any?(owned_paths, fn {_pid, p} -> p == path end)
   end
 
   @compile {:inline, i: 1}
@@ -169,6 +233,21 @@ defmodule Plug.Upload do
     {:reply, {:ok, dirs}, dirs}
   end
 
+  def handle_call(:roots, _from, dirs) do
+    {:reply, {:ok, dirs}, dirs}
+  end
+
+  def handle_call({:give_away, pid, tmp, path}, _from, dirs) do
+    # In the case of accepting a file from another process we need to be sure
+    # that the given file is definitely monitored before removing the original
+    # reference in the @path_table
+    Process.monitor(pid)
+    :ets.insert_new(@dir_table, {pid, tmp})
+    :ets.insert(@path_table, {pid, path})
+
+    {:reply, :ok, dirs}
+  end
+
   @impl true
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
     case :ets.lookup(@dir_table, pid) do
@@ -200,5 +279,6 @@ defmodule Plug.Upload do
 
   defp delete_path({_pid, path}) do
     :file.delete(path)
+    :ok
   end
 end

--- a/test/plug/upload_test.exs
+++ b/test/plug/upload_test.exs
@@ -30,4 +30,148 @@ defmodule Plug.UploadTest do
     :ok = Plug.Upload.terminate(:shutdown, [])
     refute File.exists?(path)
   end
+
+  test "give_away/3 assigns ownership to other pid" do
+    parent = self()
+
+    {other_pid, other_ref} =
+      spawn_monitor(fn ->
+        receive do
+          :exit -> nil
+        end
+      end)
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        {:ok, path1} = Plug.Upload.random_file("sample")
+        send(parent, {:path1, path1})
+        File.open!(path1)
+
+        {:ok, path2} = Plug.Upload.random_file("sample")
+        send(parent, {:path2, path2})
+        File.open!(path2)
+
+        {:ok, path3} = Plug.Upload.random_file("sample")
+        send(parent, {:path3, path3})
+        File.open!(path3)
+
+        :ok = Plug.Upload.give_away(path1, other_pid)
+        :ok = Plug.Upload.give_away(path2, other_pid)
+      end)
+
+    path1 =
+      receive do
+        {:path1, path} -> path
+      after
+        1_000 -> flunk("didn't get a path")
+      end
+
+    path2 =
+      receive do
+        {:path2, path} -> path
+      after
+        1_000 -> flunk("didn't get a path")
+      end
+
+    path3 =
+      receive do
+        {:path3, path} -> path
+      after
+        1_000 -> flunk("didn't get a path")
+      end
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, :normal} ->
+        {:ok, _} = Plug.Upload.random_file("sample")
+
+        assert File.exists?(path1)
+        assert File.exists?(path2)
+        refute File.exists?(path3)
+    end
+
+    send(other_pid, :exit)
+
+    receive do
+      {:DOWN, ^other_ref, :process, ^other_pid, :normal} ->
+        # force sync by creating file in unknown process
+        parent = self()
+
+        spawn(fn ->
+          {:ok, _} = Plug.Upload.random_file("sample")
+          send(parent, :continue)
+        end)
+
+        receive do
+          :continue -> :ok
+        end
+
+        refute File.exists?(path1)
+        refute File.exists?(path2)
+    end
+  end
+
+  test "give_away/3 assigns ownership to other pid which has existing uploads" do
+    parent = self()
+
+    {other_pid, other_ref} =
+      spawn_monitor(fn ->
+        {:ok, path} = Plug.Upload.random_file("recipient")
+        send(parent, {:recipient, path})
+
+        receive do
+          :exit -> nil
+        end
+      end)
+
+    path =
+      receive do
+        {:recipient, path} -> path
+      after
+        1_000 -> flunk("didn't get a path")
+      end
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        {:ok, path1} = Plug.Upload.random_file("sample")
+        send(parent, {:path1, path1})
+        File.open!(path1)
+
+        :ok = Plug.Upload.give_away(path1, other_pid)
+      end)
+
+    path1 =
+      receive do
+        {:path1, path} -> path
+      after
+        1_000 -> flunk("didn't get a path")
+      end
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, :normal} ->
+        {:ok, _} = Plug.Upload.random_file("sample")
+
+        assert File.exists?(path)
+        assert File.exists?(path1)
+    end
+
+    send(other_pid, :exit)
+
+    receive do
+      {:DOWN, ^other_ref, :process, ^other_pid, :normal} ->
+        # force sync by creating file in unknown process
+        parent = self()
+
+        spawn(fn ->
+          {:ok, _} = Plug.Upload.random_file("sample")
+          send(parent, :continue)
+        end)
+
+        receive do
+          :continue -> :ok
+        end
+
+        refute File.exists?(path)
+        refute File.exists?(path1)
+    end
+  end
 end


### PR DESCRIPTION
A follow on to #997 that implements `Plug.Upload.give_away/3` based on the new atomic operations and the discussion there.

I've tried to keep the action operations performed inside `handle_call/3` as light as possible, so I've kept the bit where we try to create a tmp dir out of the server process, which adds a little dance to the code run from the "giver".