### PR TITLE
fix for TLS 1.3

### DIFF
--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -242,9 +242,18 @@ defmodule Plug.SSL do
   end
 
   defp set_secure_defaults(options) do
-    options
-    |> Keyword.put_new(:secure_renegotiate, true)
-    |> Keyword.put_new(:reuse_sessions, true)
+    if List.keyfind(options, :versions, 0) == {:versions, [:"tlsv1.3"]} do
+      # secure_renegotiate and reuse_sessions options are not supported
+      # by the OTP SSL module when earlier versions of TLS are not being used.
+      # (i.e. TLS1.2 or earlier versions must be specified as it's not supported in TLS1.3)
+      options
+      |> Keyword.delete(:secure_renegotiate)
+      |> Keyword.delete(:reuse_sessions)
+    else
+      options
+      |> Keyword.put_new(:secure_renegotiate, true)
+      |> Keyword.put_new(:reuse_sessions, true)
+    end
   end
 
   defp configure_managed_tls(options) do

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -242,7 +242,7 @@ defmodule Plug.SSL do
   end
 
   defp set_secure_defaults(options) do
-    if List.keyfind(options, :versions, 0) == {:versions, [:"tlsv1.3"]} do
+    if options[:versions] == [:"tlsv1.3"] do
       # secure_renegotiate and reuse_sessions options are not supported
       # by the OTP SSL module when earlier versions of TLS are not being used.
       # (i.e. TLS1.2 or earlier versions must be specified as it's not supported in TLS1.3)


### PR DESCRIPTION
secure_renegotiate and reuse_sessions options are not supported by the OTP SSL module when earlier version of TLS are not being used. (i.e. when we specify only TSL1.3 version, without TLS1.2 or earlier versions).
It seems TLS1.2 or earlier must ALSO be specified for this to work, since it's not supported in TLS1.3. Hence, adding a check whether TLS1.3 is the ONLY version being used.
