### PR TITLE
Use ASCII mode upcasing in Plug.MethodOverride

### DIFF
--- a/lib/plug/method_override.ex
+++ b/lib/plug/method_override.ex
@@ -39,7 +39,7 @@ defmodule Plug.MethodOverride do
   end
 
   defp override_method(conn, body_params) do
-    method = String.upcase(body_params["_method"] || "")
+    method = String.upcase(body_params["_method"] || "", :ascii)
 
     if method in @allowed_methods do
       %{conn | method: method}


### PR DESCRIPTION
The given method will be compared against supported HTTP methods anyways, there is no need for default mode upcasing.