### PR TITLE
Improve Options docs for Conn.configure_session/2

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1606,10 +1606,10 @@ defmodule Plug.Conn do
 
   ## Options
 
-    * `:renew` - generates a new session id for the cookie
-    * `:drop` - drops the session, a session cookie will not be included in the
+    * `:renew` - When `true`, generates a new session id for the cookie
+    * `:drop` - When `true`, drops the session, a session cookie will not be included in the
       response
-    * `:ignore` - ignores all changes made to the session in this request cycle
+    * `:ignore` - When `true`, ignores all changes made to the session in this request cycle
 
   """
   @spec configure_session(t, Keyword.t()) :: t


### PR DESCRIPTION
In this StackOverflow answer, the call to `Conn.configure_session/2` is incorrect: https://stackoverflow.com/a/42719823. The function's API doc could be improved to make it more clear that the options are a keyword list containing `{atom, boolean}` values.