### PR TITLE
Mark opts as unused inside plug module docs

### DIFF
--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -30,7 +30,7 @@ defmodule Plug do
 
   Here's an example of a function plug:
 
-      def json_header_plug(conn, opts) do
+      def json_header_plug(conn, _opts) do
         Plug.Conn.put_resp_content_type(conn, "application/json")
       end
 


### PR DESCRIPTION
Since we don't use `opts` inside the function, we should mark it with underscore, i guess.