### PR TITLE
Fix mime deprecation warning message.

### DIFF
--- a/lib/plug/mime.ex
+++ b/lib/plug/mime.ex
@@ -21,11 +21,11 @@ defmodule Plug.MIME do
     """)
   end
 
-  @deprecated "Use MIME.valid?/1 instead"
+  @deprecated "Use MIME.extensions(type) != [] instead"
   def valid?(type) do
     IO.puts(
       :stderr,
-      "Plug.MIME.valid?/1 is deprecated, please use MIME.valid?/1 instead\n" <>
+      "Plug.MIME.valid?/1 is deprecated, please use MIME.extensions(type) != [] instead\n" <>
         Exception.format_stacktrace()
     )
 


### PR DESCRIPTION
This commit https://github.com/elixir-plug/plug/commit/8880ef913cd9924150f4ef59e9180ecf2e6c7f9a have recently replaced the call from `MIME.valid?(type)` to `MIME.extensions(type) != []`, since `MIME.valid?/1` was deprecated.

But it not changed the deprecation message as well, so it continued asking to call `MIME.valid?/1`, which is deprecated.

So this PR fix it. 

The new message is similar to the original warning messaged showed when `MIME/valid/1` is called:

```elixir
iex> MIME.valid?('foo')
false
iex> warning: MIME.valid?/1 is deprecated. Use MIME.extensions(type) != [] instead
```