### PR TITLE
Update Plug.Conn.Adapter behaviour to allow nil payloads

### DIFF
--- a/lib/plug/conn/adapter.ex
+++ b/lib/plug/conn/adapter.ex
@@ -103,7 +103,7 @@ defmodule Plug.Conn.Adapter do
   it can be used during testing.
   """
   @callback chunk(payload, body :: Conn.body()) ::
-              :ok | {:ok, sent_body :: binary, payload} | {:error, term}
+              :ok | {:ok, sent_body :: binary | nil, payload} | {:error, term}
 
   @doc """
   Reads the request body.


### PR DESCRIPTION
Fixes Dialyzer warnings emitted for plug adapters which adhere to the spirit of the accompanying documentation and return nil as a payload.