### PR TITLE
fix warning message on __STACKTRACE__

### DIFF
--- a/lib/plug/conn/wrapper_error.ex
+++ b/lib/plug/conn/wrapper_error.ex
@@ -20,7 +20,7 @@ defmodule Plug.Conn.WrapperError do
 
   @deprecated "Use reraise/1 or reraise/4 instead"
   def reraise(conn, kind, reason) do
-    reraise(conn, kind, reason, System.stacktrace())
+    reraise(conn, kind, reason, __STACKTRACE__)
   end
 
   def reraise(_conn, :error, %__MODULE__{stack: stack} = reason, _stack) do


### PR DESCRIPTION
Fix the warning message when compiling `mix deps.compile`

![Screen Shot 2021-05-03 at 10 08 49 AM](https://user-images.githubusercontent.com/806135/116894369-96310980-abf7-11eb-9dee-9358469efbb3.png)
