### PR TITLE
Plug.Static from: MFA

### DIFF
--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -10,9 +10,9 @@ defmodule Plug.Static do
     * `:from` - the file system path to read static assets from.
       It can be either: a string containing a file system path, an
       atom representing the application name (where assets will
-      be served from `priv/static`), or a tuple containing the
+      be served from `priv/static`), a tuple containing the
       application name and the directory to serve assets from (besides
-      `priv/static`).
+      `priv/static`), or an MFA tuple.
 
   The preferred form is to use `:from` with an atom or tuple, since
   it will make your application independent from the starting directory.
@@ -141,6 +141,7 @@ defmodule Plug.Static do
     from =
       case Keyword.fetch!(opts, :from) do
         {_, _} = from -> from
+        {_, _, _} = from -> from
         from when is_atom(from) -> {from, "priv/static"}
         from when is_binary(from) -> from
         _ -> raise ArgumentError, ":from must be an atom, a binary or a tuple"
@@ -390,6 +391,10 @@ defmodule Plug.Static do
       accept |> Plug.Conn.Utils.list() |> Enum.any?(encoding?)
     end)
   end
+
+  defp path({module, function, arguments}, segments)
+       when is_atom(module) and is_atom(function) and is_list(arguments),
+       do: Path.join([apply(module, function, arguments) | segments])
 
   defp path({app, from}, segments) when is_atom(app) and is_binary(from),
     do: Path.join([Application.app_dir(app), from | segments])

--- a/test/plug/static_test.exs
+++ b/test/plug/static_test.exs
@@ -580,4 +580,17 @@ defmodule Plug.StaticTest do
     assert conn.status == 200
     assert get_resp_header(conn, "x-custom") == ["x-value"]
   end
+
+  test "MFA from" do
+    opts = [
+      at: "/public",
+      from: {Path, :expand, ["..", __DIR__]}
+    ]
+
+    conn =
+      conn(:get, "/public/fixtures/static.txt")
+      |> Plug.Static.call(Plug.Static.init(opts))
+
+    assert conn.status == 200
+  end
 end


### PR DESCRIPTION
Allow using MFA for Plug.Static `:from` field configuration. This will allow calculating `:from` dynamically at runtime instead of compile time. It will be useful for upload handling in production.