### PR TITLE
fix: &handle_errors/2 behaviour spec

### DIFF
--- a/lib/plug/error_handler.ex
+++ b/lib/plug/error_handler.ex
@@ -49,9 +49,9 @@ defmodule Plug.ErrorHandler do
   Called when an exception is raised during the processing of a plug.
   """
   @callback handle_errors(Plug.Conn.t(), %{
-              type: :error | :throw | :exit,
+              kind: :error | :throw | :exit,
               reason: Exception.t() | term(),
-              stacktrace: Exception.stacktrace()
+              stack: Exception.stacktrace()
             }) :: no_return()
 
   @doc false


### PR DESCRIPTION
Looking at: https://github.com/elixir-plug/plug/blob/master/lib/plug/error_handler.ex#L113
The spec keys should be `kind` and `stack`, instead of `type` and `stacktrace`.