### PR TITLE
Admits spec path param starting with uppercase letter

### DIFF
--- a/lib/plug/router/utils.ex
+++ b/lib/plug/router/utils.ex
@@ -79,6 +79,9 @@ defmodule Plug.Router.Utils do
       iex> Plug.Router.Utils.build_path_match("/foo/:id")
       {[:id], ["foo", {:id, [], nil}]}
 
+      iex> Plug.Router.Utils.build_path_match("/foo/:Id")
+      {[:Id], ["foo", {:Id, [], nil}]}
+
   """
   def build_path_match(path, context \\ nil) when is_binary(path) do
     case build_path_clause(path, true, context) do
@@ -220,13 +223,13 @@ defmodule Plug.Router.Utils do
     {params, Enum.reverse(match), guards, post_match}
   end
 
-  defp parse_suffix(<<h, t::binary>>) when h in ?a..?z or h == ?_,
+  defp parse_suffix(<<h, t::binary>>) when h in ?a..?z or h in ?A..?Z or h == ?_,
     do: parse_suffix(t, <<h>>)
 
   defp parse_suffix(suffix) do
     raise Plug.Router.InvalidSpecError,
           "invalid dynamic path. The characters : and * must be immediately followed by " <>
-            "lowercase letters or underscore, got: :#{suffix}"
+            "lowercase/uppercase letters or underscore, got: :#{suffix}"
   end
 
   defp parse_suffix(<<h, t::binary>>, acc) when h in ?a..?z or h in ?A..?Z or h == ?_,

--- a/test/plug/router/utils_test.exs
+++ b/test/plug/router/utils_test.exs
@@ -59,7 +59,7 @@ defmodule Plug.Router.UtilsTest do
 
   test "build invalid match with empty matches" do
     assert_raise Plug.Router.InvalidSpecError,
-                 "invalid dynamic path. The characters : and * must be immediately followed by lowercase letters or underscore, got: :",
+                 "invalid dynamic path. The characters : and * must be immediately followed by lowercase/uppercase letters or underscore, got: :",
                  fn -> build_path_match("/foo/:") end
   end
 


### PR DESCRIPTION
Ciao,
I'm having troubles with a spec where the path parameters are defined with a starting uppercase character (e.g. `/hello/:WorlD`).

Looking at [here](https://github.com/elixir-plug/plug/blob/master/lib/plug/router/utils.ex#L229) it appears the plug does not allow that, and indeed I get this error when I try to crunch the request:

```
** (Plug.Router.InvalidSpecError) invalid dynamic path. The characters : and * must be immediately followed by lowercase letters or underscore, got: :Hello
    (plug 1.12.1) lib/plug/router/utils.ex:227: Plug.Router.Utils.parse_suffix/1
    (plug 1.12.1) lib/plug/router/utils.ex:145: Plug.Router.Utils.build_path_clause/7
    (plug 1.12.1) lib/plug/router/utils.ex:126: Plug.Router.Utils.build_path_clause/3
    (plug 1.12.1) lib/plug/router.ex:521: Plug.Router.__route__/4
    test/tools/sbi_test_server.ex:12: (module)
```


I tried to document myself to find out the origin of the lowercase starting letter constraint here:
- [rfc3986](https://datatracker.ietf.org/doc/html/rfc3986)
- [openapi spec](https://swagger.io/specification/)

but I could not figure the provenience of this. 
I noticed that line [232](https://github.com/elixir-plug/plug/blob/master/lib/plug/router/utils.ex#L232) admits for A-Z, which is lost in line [223](https://github.com/elixir-plug/plug/blob/master/lib/plug/router/utils.ex#L223).

Sorry if I'm  forgetting something trivial.. 
