### PR TITLE
Raise an error when providing path not starting with "/" in `Plug.Adapters.Test.Conn`

### DIFF
--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -8,6 +8,10 @@ defmodule Plug.Adapters.Test.Conn do
     maybe_flush()
 
     uri = URI.parse(uri)
+    if is_binary(uri.path) && not String.starts_with?(uri.path, "/") do
+      raise ArgumentError, message: "The URI path needs to start with \"/\", got #{uri.path}"
+    end
+
     method = method |> to_string |> String.upcase()
     query = uri.query || ""
     owner = self()

--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -8,8 +8,8 @@ defmodule Plug.Adapters.Test.Conn do
     maybe_flush()
 
     uri = URI.parse(uri)
-    if is_binary(uri.path) && not String.starts_with?(uri.path, "/") do
-      raise ArgumentError, message: "The URI path needs to start with \"/\", got #{uri.path}"
+    if is_binary(uri.path) and not String.starts_with?(uri.path, "/") do
+      raise ArgumentError, "the URI path needs to start with \"/\", got: #{inspect(uri.path)}"
     end
 
     method = method |> to_string |> String.upcase()

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -84,7 +84,7 @@ defmodule Plug.Adapters.Test.ConnTest do
   end
 
   test "path not starting with slash" do
-    assert_raise ArgumentError, "The URI path needs to start with \"/\", got foo", fn ->
+    assert_raise ArgumentError, ~S(the URI path needs to start with "/", got: "foo"), fn ->
       conn(:get, "foo")
     end
   end

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -83,6 +83,12 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert conn.path_info == []
   end
 
+  test "path not starting with slash" do
+    assert_raise ArgumentError, "The URI path needs to start with \"/\", got foo", fn ->
+      conn(:get, "foo")
+    end
+  end
+
   test "custom params sets no content-type for GET/HEAD requests" do
     conn = conn(:head, "/")
     assert conn.req_headers == []

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -517,14 +517,14 @@ defmodule Plug.ConnTest do
       ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\rBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
-      put_resp_header(conn(:get, "foo"), "x-sample", "value\rBAR")
+      put_resp_header(conn(:get, "/foo"), "x-sample", "value\rBAR")
     end
 
     message =
       ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\n\nBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
-      put_resp_header(conn(:get, "foo"), "x-sample", "value\n\nBAR")
+      put_resp_header(conn(:get, "/foo"), "x-sample", "value\n\nBAR")
     end
   end
 
@@ -571,14 +571,14 @@ defmodule Plug.ConnTest do
       ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\rBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
-      prepend_resp_headers(conn(:get, "foo"), [{"x-sample", "value\rBAR"}])
+      prepend_resp_headers(conn(:get, "/foo"), [{"x-sample", "value\rBAR"}])
     end
 
     message =
       ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\n\nBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
-      prepend_resp_headers(conn(:get, "foo"), [{"x-sample", "value\n\nBAR"}])
+      prepend_resp_headers(conn(:get, "/foo"), [{"x-sample", "value\n\nBAR"}])
     end
   end
 
@@ -587,14 +587,14 @@ defmodule Plug.ConnTest do
       ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\rBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
-      merge_resp_headers(conn(:get, "foo"), [{"x-sample", "value\rBAR"}])
+      merge_resp_headers(conn(:get, "/foo"), [{"x-sample", "value\rBAR"}])
     end
 
     message =
       ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\n\nBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
-      merge_resp_headers(conn(:get, "foo"), [{"x-sample", "value\n\nBAR"}])
+      merge_resp_headers(conn(:get, "/foo"), [{"x-sample", "value\n\nBAR"}])
     end
   end
 


### PR DESCRIPTION
Closes #1058