### PR TITLE
Improve CacheBodyReader example for `:body_reader`

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -185,9 +185,9 @@ defmodule Plug.Parsers do
 
       defmodule CacheBodyReader do
         def read_body(conn, opts) do
-          {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
+          {ok_or_more, body, conn} = Plug.Conn.read_body(conn, opts)
           conn = update_in(conn.assigns[:raw_body], &[body | (&1 || [])])
-          {:ok, body, conn}
+          {ok_or_more, body, conn}
         end
       end
 


### PR DESCRIPTION
The current example assumes that the body you are reading is going to be less than 1_000_000 bytes, and would error otherwise.

This version of the code snippet would return the result of `Plug.Conn.read_body`, so that the `Plug.Parser` can call it again if needed.

I believe this was the intent of the snippet, as it shows you prepending the just read body in the assigns. With the current code, I think it would only ever read the body once.

Let me know what you think, thanks!
