### PR TITLE
Fix route matching for components with numbers

### DIFF
--- a/lib/plug/router/utils.ex
+++ b/lib/plug/router/utils.ex
@@ -246,8 +246,9 @@ defmodule Plug.Router.Utils do
             "lowercase letters or underscore, got: :#{suffix}"
   end
 
-  defp parse_suffix(<<h, t::binary>>, acc) when h in ?a..?z or h in ?A..?Z or h in ?0..?9 or h == ?_,
-    do: parse_suffix(t, <<acc::binary, h>>)
+  defp parse_suffix(<<h, t::binary>>, acc)
+       when h in ?a..?z or h in ?A..?Z or h in ?0..?9 or h == ?_,
+       do: parse_suffix(t, <<acc::binary, h>>)
 
   defp parse_suffix(rest, acc),
     do: {acc, rest}

--- a/test/plug/router/utils_test.exs
+++ b/test/plug/router/utils_test.exs
@@ -44,8 +44,11 @@ defmodule Plug.Router.UtilsTest do
     assert quote(@opts, do: {[:id, :name, :category], ["foo", id, name, category]}) ==
              build_path_match("/foo/:id/:name/:category")
 
-    assert quote(@opts, do: {[:username, :post_id, :comment_id], ["foo", username, post_id, comment_id]}) ==
+    assert quote(@opts,
+             do: {[:username, :post_id, :comment_id], ["foo", username, post_id, comment_id]}
+           ) ==
              build_path_match("foo/:username/:post_id/:comment_id")
+
     assert quote(@opts, do: {[:username, :post1, :post2], ["foo", username, post1, post2]}) ==
              build_path_match("foo/:username/:post1/:post2")
   end


### PR DESCRIPTION
Since 1.13.0 the matching with routes that contain numbers would fail with:
```
** (Plug.Router.InvalidSpecError) invalid dynamic path. Only letters, numbers, and underscore are allowed after : in "foo/:user1" 
    (plug 1.13.2) lib/plug/router/utils.ex:89: Plug.Router.Utils.build_path_match/2
```

This PR fixes the problem and adds tests for dynamic paths.