### PR TITLE
Add example of passing :json_decoder as an MFA

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -126,8 +126,8 @@ defmodule Plug.Parsers do
       plug Plug.Parsers,
            parsers: [:urlencoded, {:json, json_decoder: Jason}]
 
-  It is also possible to pass the `:json_decoder` as an MFA, useful for passing
-  options to the JSON decoder:
+  It is also possible to pass the `:json_decoder` as a `{module, function, args}` (MFA) tuple,
+  useful for passing options to the JSON decoder:
 
       plug Plug.Parsers,
            parsers: [:json],

--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -126,6 +126,13 @@ defmodule Plug.Parsers do
       plug Plug.Parsers,
            parsers: [:urlencoded, {:json, json_decoder: Jason}]
 
+  It is also possible to pass the `:json_decoder` as an MFA, useful for passing
+  options to the JSON decoder:
+
+      plug Plug.Parsers,
+           parsers: [:json],
+           json_decoder: {Jason, :decode!, [[floats: :decimals]]}
+
   A common set of shared options given to Plug.Parsers is `:length`,
   `:read_length` and `:read_timeout`, which customizes the maximum
   request length you want to accept. For example, to support file

--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -126,7 +126,7 @@ defmodule Plug.Parsers do
       plug Plug.Parsers,
            parsers: [:urlencoded, {:json, json_decoder: Jason}]
 
-  It is also possible to pass the `:json_decoder` as a `{module, function, args}` (MFA) tuple,
+  It is also possible to pass the `:json_decoder` as a `{module, function, args}` tuple,
   useful for passing options to the JSON decoder:
 
       plug Plug.Parsers,


### PR DESCRIPTION
A few times, most recently on the [Elixir Forum](https://elixirforum.com/t/custom-rule-for-decoding-json-input-with-jason/45888), I've wanted to customise the behaviour of the JSON parser. It's not immediately obvious from the docs how to do this, so I've added an example to the `Plug.Parsers` docs (the last sentence and code block).

<img width="860" alt="image" src="https://user-images.githubusercontent.com/498229/153113157-a429d200-d179-48ff-ad36-4e6aeef0a8b3.png">
