### PR TITLE
Pass :via to match on Plug.Router.forward/2

### DIFF
--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -414,7 +414,8 @@ defmodule Plug.Router do
   `forward` accepts the following options:
 
     * `:to` - a Plug the requests will be forwarded to.
-    * `:init_opts` - the options for the target Plug.
+    * `:init_opts` - the options for the target Plug. Should be the preferred
+                     way for passing options to the target Plug.
     * `:host` - a string representing the host or subdomain, exactly like in
       `match/3`.
     * `:private` - values for `conn.private`, exactly like in `match/3`.

--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -414,8 +414,8 @@ defmodule Plug.Router do
   `forward` accepts the following options:
 
     * `:to` - a Plug the requests will be forwarded to.
-    * `:init_opts` - the options for the target Plug. Should be the preferred
-                     way for passing options to the target Plug.
+    * `:init_opts` - the options for the target Plug. It is the preferred
+      mechanism for passing options to the target Plug.
     * `:host` - a string representing the host or subdomain, exactly like in
       `match/3`.
     * `:private` - values for `conn.private`, exactly like in `match/3`.

--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -446,7 +446,7 @@ defmodule Plug.Router do
   defmacro forward(path, options) do
     quote bind_quoted: [path: path, options: options] do
       {target, options} = Keyword.pop(options, :to)
-      {options, plug_options} = Keyword.split(options, [:host, :private, :assigns])
+      {options, plug_options} = Keyword.split(options, [:via, :host, :private, :assigns])
       plug_options = Keyword.get(plug_options, :init_opts, plug_options)
 
       if is_nil(target) or not is_atom(target) do

--- a/test/plug/router_test.exs
+++ b/test/plug/router_test.exs
@@ -23,6 +23,8 @@ defmodule Plug.RouterTest do
       Process.put(:plug_forward_call, true)
     end
 
+    forward "/forward_via", via: [:put, :post], to: SamplePlug, init_opts: [route: :via]
+
     get "/" do
       resp(conn, 200, "forwarded")
     end
@@ -551,6 +553,14 @@ defmodule Plug.RouterTest do
   test "declare and call OPTIONS requests" do
     conn = call(Sample, conn(:options, "/options"))
     assert conn.status == 200
+  end
+
+  test "forwards only :via methods" do
+    for method <- [:post, :put] do
+      resp = call(Forward, conn(method, "/forward_via"))
+      assert resp.status == 200
+      assert resp.resp_body == "[route: :via]"
+    end
   end
 
   test "assigns options on forward" do


### PR DESCRIPTION
Proposal to pass the :via option to the `match` call. This allows Plug.Router.forward to only forward certain methods.