### PR TITLE
Refactor get_req_header and get_resp_header

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -617,7 +617,10 @@ defmodule Plug.Conn do
   """
   @spec get_req_header(t, binary) :: [binary]
   def get_req_header(%Conn{req_headers: headers}, key) when is_binary(key) do
-    for {^key, value} <- headers, do: value
+    Enum.find_value(headers, fn
+      {^key, value} -> [value]
+      _header -> []
+    end)
   end
 
   @doc """
@@ -730,7 +733,10 @@ defmodule Plug.Conn do
   """
   @spec get_resp_header(t, binary) :: [binary]
   def get_resp_header(%Conn{resp_headers: headers}, key) when is_binary(key) do
-    for {^key, value} <- headers, do: value
+    Enum.find_value(headers, fn
+      {^key, value} -> [value]
+      _header -> []
+    end)
   end
 
   @doc ~S"""


### PR DESCRIPTION
Instead of iterating through all values, iterates only until the header is found.

When more than one header with same key is sent, like `Accept-Language: en_US`, `Accept-Language: pt_BR`, `Accept-Language: en_GB`, the `req_header` comes as `{"accept-language", "en_US, pt_BR, en_GB"}`. So, returning the first found value is fine.

By the way, personally I preferred to return the value itself, but to be backwards compatible, I'm returning it wrapped on a list.