### PR TITLE
Preserve query string in `:last_path`

### DIFF
--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -267,8 +267,16 @@ defmodule Plug.Debugger do
     end
   end
 
-  defp actions_redirect_path(%Plug.Conn{method: "GET", request_path: request_path}),
-    do: request_path
+  defp actions_redirect_path(%Plug.Conn{
+         method: "GET",
+         request_path: request_path,
+         query_string: query_string
+       }) do
+    case query_string do
+      "" -> request_path
+      query_string -> "#{request_path}?#{query_string}"
+    end
+  end
 
   defp actions_redirect_path(conn) do
     case get_req_header(conn, "referer") do

--- a/test/plug/debugger_test.exs
+++ b/test/plug/debugger_test.exs
@@ -422,8 +422,20 @@ defmodule Plug.DebuggerTest do
     refute body =~ ~s|<form action="/__plug__/debugger/action" method="POST">|
   end
 
-  test "sets last path as the current request path when is a GET" do
+  test "sets last path as the current request path when is a GET without query string" do
     path = "/actionable_exception"
+
+    conn =
+      conn(:get, path)
+      |> put_req_header("accept", "text/html")
+      |> Map.put(:secret_key_base, "secret")
+
+    %Plug.Conn{resp_body: body} = render(conn, [], fn -> raise ActionableError end)
+    assert body =~ ~s|<input type="hidden" name="last_path" value="#{path}">|
+  end
+
+  test "sets last path as the current request path when is a GET with query string" do
+    path = "/actionable_exception?a=b"
 
     conn =
       conn(:get, path)


### PR DESCRIPTION
This is crucial for pages, where without some GET parameters you simply lose access to the page after running plug action