### PR TITLE
Debugger page design update

### DIFF
--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -224,6 +224,7 @@
 
     .frame-info {
         background: white;
+        border-radius: 4px;
         box-shadow:
             0 1px 3px rgba(80, 100, 140, .1),
             0 8px 15px rgba(80, 100, 140, .05);
@@ -478,6 +479,7 @@
     .stack-trace-item:hover,
     .stack-trace-item:focus {
         background-color: rgba(80, 100, 140, 0.05);
+        border-radius: 4px;
     }
 
     .stack-trace-item,
@@ -490,7 +492,8 @@
     }
 
     .stack-trace-item.-active {
-        background-color: white;
+        background-color: rgba(80, 100, 140, 0.1);
+        border-radius: 4px;
     }
 
     /* Circle */
@@ -502,11 +505,15 @@
         background: #a0b0c0;
         border-radius: 50%;
         margin-right: 8px;
+        opacity: 0.5;
+    }
+
+    .stack-trace-item.-active > .left:before {
+        opacity: 1;
     }
 
     .stack-trace-item.-app > .left:before {
         background: <%= @style.primary %>;
-        opacity: 1;
     }
 
     .stack-trace-item.-app > .left > .app {
@@ -715,7 +722,7 @@
                         <div class="frame-mfa">
                             <%= h frame.info %>
                             <%= if doc = frame.doc do %>
-                                <a class="docs right" href="<%= h doc %>">docs</a>
+                                <a class="docs right" href="<%= h doc %>">Docs</a>
                             <% end %>
                             <%= if app = frame.app do %>
                                 <span class="app right"><%= h app %></span>

--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -567,6 +567,10 @@
         white-space: normal;
     }
 
+    .code-quote > pre {
+        margin: 0;
+    }
+
     .code.-padded {
         padding: 0 16px 16px 16px;
     }
@@ -668,6 +672,7 @@
         background-color: inherit;
         background-color: #f2f2f4;
     }
+
     </style>
 </head>
 <body>
@@ -827,7 +832,7 @@
             <%= for {key, value} <- @session do %>
             <dl>
                 <dt><%= h key %></dt>
-                <dd><pre><%= h inspect(value) %></pre></dd>
+                <dd class="code-quote"><pre><%= h inspect(value) %></pre></dd>
             </dl>
             <% end %>
         </details>


### PR DESCRIPTION
I updated the design for the debugger page to add a little more contrast to the currently selected entry (and added some border-radius).
Also fixed the display of entries in the session section.

Before:
<img width="1514" alt="old" src="https://user-images.githubusercontent.com/792046/167269820-6c6f4f03-c877-4d35-a4bd-a9de7c9851c5.png">

After:
<img width="1514" alt="new" src="https://user-images.githubusercontent.com/792046/167269822-3ec5fb93-b139-4435-a90d-6dad537b5ab4.png">

Session before:
<img width="1514" alt="Screenshot 2022-05-07 at 21 47 25" src="https://user-images.githubusercontent.com/792046/167269827-227d921c-d005-4288-b31d-75aa582326f2.png">

Session after:
<img width="1514" alt="Screenshot 2022-05-07 at 21 46 41" src="https://user-images.githubusercontent.com/792046/167269834-d87a01d0-2d65-4ba6-8669-e328acdbf0ee.png">


