### PR TITLE
Do not show docs link for defimpl

### DIFF
--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -400,16 +400,13 @@ defmodule Plug.Debugger do
   defp has_docs?(module, name, arity) do
     case Code.fetch_docs(module) do
       {:docs_v1, _, _, _, module_doc, _, docs} when module_doc != :hidden ->
-        if impl?(docs) do
-          false
-        else
-          Enum.any?(docs, has_doc_matcher?(name, arity))
-        end
+        Enum.any?(docs, has_doc_matcher?(name, arity))
 
       _ ->
         false
     end
   end
+
   defp has_doc_matcher?(name, arity) do
     &match?(
       {{kind, ^name, ^arity}, _, _, doc, _}

--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -400,11 +400,19 @@ defmodule Plug.Debugger do
   defp has_docs?(module, name, arity) do
     case Code.fetch_docs(module) do
       {:docs_v1, _, _, _, module_doc, _, docs} when module_doc != :hidden ->
-        Enum.any?(docs, has_doc_matcher?(name, arity))
+        if impl?(docs) do
+          false
+        else
+          Enum.any?(docs, has_doc_matcher?(name, arity))
+        end
 
       _ ->
         false
     end
+  end
+
+  defp impl?(docs) do
+    Enum.any?(docs, &match?({{:function, :__impl__, 1}, _, _, _, _}, &1))
   end
 
   defp has_doc_matcher?(name, arity) do

--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -410,15 +410,10 @@ defmodule Plug.Debugger do
         false
     end
   end
-
-  defp impl?(docs) do
-    Enum.any?(docs, &match?({{:function, :__impl__, 1}, _, _, _, _}, &1))
-  end
-
   defp has_doc_matcher?(name, arity) do
     &match?(
       {{kind, ^name, ^arity}, _, _, doc, _}
-      when kind in [:function, :macro] and doc != :hidden,
+      when kind in [:function, :macro] and doc != :hidden and doc != :none,
       &1
     )
   end


### PR DESCRIPTION
The docs links for protocol implementations don't work, because of the combined module names, e.g `Phoenix.HTML.Safe.Phoenix.LiveView.Rendered.to_iodata/1` which links to  the nonexistent `https://hexdocs.pm/phoenix_live_view/0.17.9/Phoenix.HTML.Safe.Phoenix.LiveView.Rendered.html#to_iodata/1`.

I added a check, for the `__impl__/1` function and if the module contains the function, it shouldn't show the docs link.
