### PR TITLE
Add path information to InvalidPathError error message

### DIFF
--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -185,7 +185,7 @@ defmodule Plug.Static do
       segments = Enum.map(segments, &uri_decode/1)
 
       if invalid_path?(segments) do
-        raise InvalidPathError, message: "invalid path for static asset #{conn.request_path}"
+        raise InvalidPathError, "invalid path for static asset: #{conn.request_path}"
       end
 
       path = path(from, segments)

--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -185,7 +185,7 @@ defmodule Plug.Static do
       segments = Enum.map(segments, &uri_decode/1)
 
       if invalid_path?(segments) do
-        raise InvalidPathError
+        raise InvalidPathError, message: "invalid path for static asset #{conn.request_path}"
       end
 
       path = path(from, segments)

--- a/test/plug/static_test.exs
+++ b/test/plug/static_test.exs
@@ -206,37 +206,49 @@ defmodule Plug.StaticTest do
   end
 
   test "returns 400 for unsafe paths" do
+    path = "/public/fixtures/../fixtures/static/file.txt"
+
     exception =
-      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset", fn ->
-        call(conn(:get, "/public/fixtures/../fixtures/static/file.txt"))
+      assert_raise Plug.Static.InvalidPathError,
+                   "invalid path for static asset #{path}",
+                   fn ->
+                     call(conn(:get, path))
+                   end
+
+    assert Plug.Exception.status(exception) == 400
+
+    path = "/public/fixtures/%2E%2E/fixtures/static/file.txt"
+
+    exception =
+      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset #{path}", fn ->
+        call(conn(:get, path))
       end
 
     assert Plug.Exception.status(exception) == 400
 
+    path = "/public/c:\\foo.txt"
+
     exception =
-      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset", fn ->
-        call(conn(:get, "/public/fixtures/%2E%2E/fixtures/static/file.txt"))
+      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset #{path}", fn ->
+        call(conn(:get, path))
       end
 
     assert Plug.Exception.status(exception) == 400
 
+    path = "/public/sample.txt%00.html"
+
     exception =
-      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset", fn ->
-        call(conn(:get, "/public/c:\\foo.txt"))
+      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset #{path}", fn ->
+        call(conn(:get, path))
       end
 
     assert Plug.Exception.status(exception) == 400
 
-    exception =
-      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset", fn ->
-        call(conn(:get, "/public/sample.txt%00.html"))
-      end
-
-    assert Plug.Exception.status(exception) == 400
+    path = "/public/sample.txt\0.html"
 
     exception =
-      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset", fn ->
-        call(conn(:get, "/public/sample.txt\0.html"))
+      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset #{path}", fn ->
+        call(conn(:get, path))
       end
 
     assert Plug.Exception.status(exception) == 400

--- a/test/plug/static_test.exs
+++ b/test/plug/static_test.exs
@@ -210,7 +210,7 @@ defmodule Plug.StaticTest do
 
     exception =
       assert_raise Plug.Static.InvalidPathError,
-                   "invalid path for static asset #{path}",
+                   "invalid path for static asset: #{path}",
                    fn ->
                      call(conn(:get, path))
                    end
@@ -220,7 +220,7 @@ defmodule Plug.StaticTest do
     path = "/public/fixtures/%2E%2E/fixtures/static/file.txt"
 
     exception =
-      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset #{path}", fn ->
+      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset: #{path}", fn ->
         call(conn(:get, path))
       end
 
@@ -229,7 +229,7 @@ defmodule Plug.StaticTest do
     path = "/public/c:\\foo.txt"
 
     exception =
-      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset #{path}", fn ->
+      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset: #{path}", fn ->
         call(conn(:get, path))
       end
 
@@ -238,7 +238,7 @@ defmodule Plug.StaticTest do
     path = "/public/sample.txt%00.html"
 
     exception =
-      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset #{path}", fn ->
+      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset: #{path}", fn ->
         call(conn(:get, path))
       end
 
@@ -247,7 +247,7 @@ defmodule Plug.StaticTest do
     path = "/public/sample.txt\0.html"
 
     exception =
-      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset #{path}", fn ->
+      assert_raise Plug.Static.InvalidPathError, "invalid path for static asset: #{path}", fn ->
         call(conn(:get, path))
       end
 


### PR DESCRIPTION
closes #1097 

I added to the existing error message the `conn.request_path`