### PR TITLE
Extract MFA for only, only_matching

### DIFF
--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -180,6 +180,7 @@ defmodule Plug.Static do
       )
       when meth in @allowed_methods do
     segments = subset(at, conn.path_info)
+    only_rules = derive_only_rules(only_rules)
 
     if allowed?(only_rules, segments) do
       segments = Enum.map(segments, &uri_decode/1)
@@ -210,6 +211,16 @@ defmodule Plug.Static do
         raise InvalidPathError
     end
   end
+
+  defp derive_only_rules({only, only_matching}),
+    do: {derive_only(only), derive_only(only_matching)}
+
+  defp derive_only({module, function, arguments})
+       when is_atom(module) and is_atom(function) and is_list(arguments) do
+    apply(module, function, arguments)
+  end
+
+  defp derive_only(only) when is_list(only), do: only
 
   defp allowed?(_only_rules, []), do: false
   defp allowed?({[], []}, _list), do: true


### PR DESCRIPTION
This PR adds an MFA tuple option to both `only` and `only_matching`.

I'm using this in a phx project like so:
```elixir
defmodule PagesWeb.StaticDigest do
  @moduledoc """
  This module contains utilities for working with static assets
  that have been digested (`mix phx.digest`).
  """

  @doc """
  Generate 'only rules' for digested static assets based on existing
  rules from the user.
  """
  def generate_only_rules(endpoint, only)
      when is_list(only) do
    latest = endpoint.config(:cache_static_manifest_latest, %{})

    digest_only =
      only
      |> Stream.filter(fn x -> Map.has_key?(latest, x) end)
      |> Enum.map(fn x -> Map.get(latest, x) end)

    only ++ digest_only
  end
end

# In the Endpoint
  plug Plug.Static,
    at: "/",
    from: :pages_web,
    gzip: false,
    only:
      {PagesWeb.StaticDigest, :generate_only_rules,
       [
         __MODULE__,
         ~w(assets css fonts images js sprites favicon.ico favicon.svg site.webmanifest browserconfig.xml robots.txt)
       ]}
```

This has the effect of allowing the digested versions of all of the allowed paths without needing to add a rule like `only_matching: ~w(site)`.