### PR TITLE
docs: fix typo for :urlencoded

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -139,7 +139,7 @@ defmodule Plug.Parsers do
   uploads, you can do:
 
       plug Plug.Parsers,
-           parsers: [:url_encoded, :multipart],
+           parsers: [:urlencoded, :multipart],
            length: 20_000_000
 
   However, the above will increase the maximum length of all request
@@ -148,7 +148,7 @@ defmodule Plug.Parsers do
 
       plug Plug.Parsers,
            parsers: [
-             :url_encoded,
+             :urlencoded,
              {:multipart, length: 20_000_000} # Increase to 20MB max upload
            ]
 


### PR DESCRIPTION
Hi guys,

I'm new to Elixir and I got confused by Plug.Parsers doc because of a typo I found. So here is my small correction 🙂