### PR TITLE
Raise error for `put_req_header(conn, "host", value)`

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1775,7 +1775,8 @@ defmodule Plug.Conn do
     if key == "host" do
       # host is an HTTP header, but if you store it in the main list it will be
       # overridden by conn.host.
-      raise InvalidHeaderError, "set the host header with %Plug.Conn{conn | host: \"example.com\"}"
+      raise InvalidHeaderError,
+            "set the host header with %Plug.Conn{conn | host: \"example.com\"}"
     end
 
     validate_header_key_if_test!(conn, key)

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1772,11 +1772,12 @@ defmodule Plug.Conn do
   end
 
   defp validate_req_header_key_if_test!(conn, key) do
-    if Application.fetch_env!(:plug, :validate_header_keys_during_test) and key == "host" do
+    if key == "host" do
       # host is an HTTP header, but if you store it in the main list it will be
       # overridden by conn.host.
       raise InvalidHeaderError, "set the host header with %Plug.Conn{conn | host: \"example.com\"}"
     end
+
     validate_header_key_if_test!(conn, key)
   end
 

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -659,8 +659,8 @@ defmodule Plug.Conn do
   Adds a new request header (`key`) if not present, otherwise replaces the
   previous value of that header with `value`.
 
-  Note that the "host" header will be overridden by `conn.host` and should not
-  be set with this method. Instead, do `%{conn | host: value}`.
+  The "host" header will be overridden by `conn.host` and should not be set
+  with this method. Instead, do `%Plug.Conn{conn | host: value}`.
 
   Because header keys are case-insensitive in both HTTP/1.1 and HTTP/2,
   it is recommended for header keys to be in lowercase, to avoid sending
@@ -1772,15 +1772,12 @@ defmodule Plug.Conn do
   end
 
   defp validate_req_header_key_if_test!(conn, key) do
-    if Application.fetch_env!(:plug, :validate_header_keys_during_test) do
-      if key == "host" do
-        # host is an HTTP header, but if you store it in the main list it will
-        # be overridden by conn.host.
-        raise InvalidHeaderError, "set the host header with %{conn | host: \"example.com\"}"
-      else
-        validate_header_key_if_test!(conn, key)
-      end
+    if Application.fetch_env!(:plug, :validate_header_keys_during_test) and key == "host" do
+      # host is an HTTP header, but if you store it in the main list it will be
+      # overridden by conn.host.
+      raise InvalidHeaderError, "set the host header with %Plug.Conn{conn | host: \"example.com\"}"
     end
+    validate_header_key_if_test!(conn, key)
   end
 
   defp validate_header_key_if_test!({Plug.Adapters.Test.Conn, _}, key) do

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -659,6 +659,9 @@ defmodule Plug.Conn do
   Adds a new request header (`key`) if not present, otherwise replaces the
   previous value of that header with `value`.
 
+  Note that the "host" header will be overridden by `conn.host` and should not
+  be set with this method. Instead, do `%{conn | host: value}`.
+
   Because header keys are case-insensitive in both HTTP/1.1 and HTTP/2,
   it is recommended for header keys to be in lowercase, to avoid sending
   duplicate keys in a request.

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -715,9 +715,11 @@ defmodule Plug.ConnTest do
       put_req_header(conn, "X-Foo", "bar")
     end
 
-    assert_raise Plug.Conn.InvalidHeaderError, ~S[set the host header with %Plug.Conn{conn | host: "example.com"}], fn ->
-      put_req_header(conn, "host", "bar")
-    end
+    assert_raise Plug.Conn.InvalidHeaderError,
+                 ~S[set the host header with %Plug.Conn{conn | host: "example.com"}],
+                 fn ->
+                   put_req_header(conn, "host", "bar")
+                 end
   end
 
   test "put_req_header/3 doesn't raise with invalid header key given when :validate_header_keys_during_test is disabled" do

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -714,6 +714,7 @@ defmodule Plug.ConnTest do
     assert_raise Plug.Conn.InvalidHeaderError, ~S[header key is not lowercase: "X-Foo"], fn ->
       put_req_header(conn, "X-Foo", "bar")
     end
+
     assert_raise Plug.Conn.InvalidHeaderError, ~S[set the host header with %Plug.Conn{conn | host: "example.com"}], fn ->
       put_req_header(conn, "host", "bar")
     end

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -714,7 +714,7 @@ defmodule Plug.ConnTest do
     assert_raise Plug.Conn.InvalidHeaderError, ~S[header key is not lowercase: "X-Foo"], fn ->
       put_req_header(conn, "X-Foo", "bar")
     end
-    assert_raise Plug.Conn.InvalidHeaderError, ~S[set the host header with %{conn | host: "example.com"}], fn ->
+    assert_raise Plug.Conn.InvalidHeaderError, ~S[set the host header with %Plug.Conn{conn | host: "example.com"}], fn ->
       put_req_header(conn, "host", "bar")
     end
   end

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -714,6 +714,9 @@ defmodule Plug.ConnTest do
     assert_raise Plug.Conn.InvalidHeaderError, ~S[header key is not lowercase: "X-Foo"], fn ->
       put_req_header(conn, "X-Foo", "bar")
     end
+    assert_raise Plug.Conn.InvalidHeaderError, ~S[set the host header with %{conn | host: "example.com"}], fn ->
+      put_req_header(conn, "host", "bar")
+    end
   end
 
   test "put_req_header/3 doesn't raise with invalid header key given when :validate_header_keys_during_test is disabled" do


### PR DESCRIPTION
The host header is overridden by `conn.host`, so trying to set the header this way will usually not do what the user intended.