### PR TITLE
Allow testing request body when passing in params

### DIFF
--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -154,6 +154,7 @@ defmodule Plug.Adapters.Test.Conn do
   defp body_or_params(params, query, headers, method)
        when is_map(params) and method in ["GET", "HEAD"] do
     params = stringify_params(params, &to_string/1)
+    encoded_params = Plug.Conn.Query.encode(params)
 
     from_query = Plug.Conn.Query.decode(query)
     params = Map.merge(from_query, params)
@@ -163,7 +164,7 @@ defmodule Plug.Adapters.Test.Conn do
       |> Map.merge(from_query)
       |> Plug.Conn.Query.encode()
 
-    {params, {query, nil}, {query, params}, headers}
+    {params, {encoded_params, nil}, {query, params}, headers}
   end
 
   defp body_or_params(params, query, headers, _method) when is_map(params) do
@@ -174,7 +175,7 @@ defmodule Plug.Adapters.Test.Conn do
     body_params = stringify_params(params, & &1)
     query_params = Plug.Conn.Query.decode(query)
     params = Map.merge(query_params, body_params)
-    encoded_params = Plug.Conn.Query.encode(params)
+    encoded_params = Plug.Conn.Query.encode(body_params)
 
     {params, {encoded_params, body_params}, {query, query_params}, headers}
   end

--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -163,7 +163,7 @@ defmodule Plug.Adapters.Test.Conn do
       |> Map.merge(from_query)
       |> Plug.Conn.Query.encode()
 
-    {params, {"", nil}, {query, params}, headers}
+    {params, {query, nil}, {query, params}, headers}
   end
 
   defp body_or_params(params, query, headers, _method) when is_map(params) do
@@ -174,8 +174,9 @@ defmodule Plug.Adapters.Test.Conn do
     body_params = stringify_params(params, & &1)
     query_params = Plug.Conn.Query.decode(query)
     params = Map.merge(query_params, body_params)
+    encoded_params = Plug.Conn.Query.encode(params)
 
-    {params, {"--plug_conn_test--", body_params}, {query, query_params}, headers}
+    {params, {encoded_params, body_params}, {query, query_params}, headers}
   end
 
   defp stringify_params([{_, _} | _] = params, value_fun),

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -21,7 +21,7 @@ defmodule Plug.Adapters.Test.ConnTest do
 
     conn = conn(:get, "/?e=f", %{"a" => "b", "c" => "d"})
     {adapter, state} = conn.adapter
-    assert {:ok, "a=b&c=d&e=f", _state} = adapter.read_req_body(state, length: 11)
+    assert {:ok, "a=b&c=d", _state} = adapter.read_req_body(state, length: 7)
 
     conn = conn(:post, "/", %{"a" => "b", "c" => "d"})
     {adapter, state} = conn.adapter
@@ -29,7 +29,7 @@ defmodule Plug.Adapters.Test.ConnTest do
 
     conn = conn(:post, "/?e=f", %{"a" => "b", "c" => "d"})
     {adapter, state} = conn.adapter
-    assert {:ok, "a=b&c=d&e=f", _state} = adapter.read_req_body(state, length: 11)
+    assert {:ok, "a=b&c=d", _state} = adapter.read_req_body(state, length: 7)
   end
 
   test "custom params" do

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -14,6 +14,24 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert {:ok, "", _state} = adapter.read_req_body(state, length: 5)
   end
 
+  test "read_req_body/2 when passing params" do
+    conn = conn(:get, "/", %{"a" => "b", "c" => "d"})
+    {adapter, state} = conn.adapter
+    assert {:ok, "a=b&c=d", _state} = adapter.read_req_body(state, length: 7)
+
+    conn = conn(:get, "/?e=f", %{"a" => "b", "c" => "d"})
+    {adapter, state} = conn.adapter
+    assert {:ok, "a=b&c=d&e=f", _state} = adapter.read_req_body(state, length: 11)
+
+    conn = conn(:post, "/", %{"a" => "b", "c" => "d"})
+    {adapter, state} = conn.adapter
+    assert {:ok, "a=b&c=d", _state} = adapter.read_req_body(state, length: 7)
+
+    conn = conn(:post, "/?e=f", %{"a" => "b", "c" => "d"})
+    {adapter, state} = conn.adapter
+    assert {:ok, "a=b&c=d&e=f", _state} = adapter.read_req_body(state, length: 11)
+  end
+
   test "custom params" do
     conn = conn(:head, "/posts", page: 2)
     assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}


### PR DESCRIPTION
I'm writing a small utility function that caches the raw body of the request as suggested in https://github.com/elixir-plug/plug/issues/691 and https://hexdocs.pm/plug/Plug.Parsers.html#module-custom-body-reader that looks like the following:

```elixir
defmodule RawBody do
  def cache_raw_body(conn, opts \\ []) do
    {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
    conn = update_in(conn.assigns[:raw_body], &[body | &1 || []])
    {:ok, body, conn}
  end
end
```

When writing a test for it I couldn't get the real values

```elixir
conn =
  conn(:get, "/test", %{
    "hello" => "world"
  })
  |> RawBody.cache_raw_body()

IO.inspect(conn)
# assigns: %{raw_body: [""]}

conn =
  conn(:post, "/test", %{
    "hello" => "world"
  })
  |> RawBody.cache_raw_body()

IO.inspect(conn)
# assigns: %{raw_body: ["--plug_conn_test--"]},
```

I thought it might be good to expose the params in both `GET` and `POST` handlers, but let me know if I misunderstood anything!
