### PR TITLE
Fix example for Plug.Parsers.MULTIPART dynamic configuration

### DIFF
--- a/lib/plug/parsers/multipart.ex
+++ b/lib/plug/parsers/multipart.ex
@@ -76,7 +76,7 @@ defmodule Plug.Parsers.MULTIPART do
         end
 
         def parse(conn, "multipart", subtype, headers, opts) do
-          length = System.fetch_env!("UPLOAD_LIMIT")
+          length = System.fetch_env!("UPLOAD_LIMIT") |> String.to_integer
           opts = @multipart.init([length: length] ++ opts)
           @multipart.parse(conn, "multipart", subtype, headers, opts)
         end


### PR DESCRIPTION
`Plug.Parsers.MULTIPART` expects a number as `length`. The following error is raised if a binary is passed:

``` 
** (Plug.Parsers.ParseError) malformed request, a ArithmeticError exception was raised with message "bad argument in arithmetic expression"
    :erlang.-("100000000", 1142962)
``` 