### PR TITLE
Fix overflowing filename in Debugger

### DIFF
--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -238,7 +238,9 @@
     .frame-info > .meta,
     .frame-info > .file {
         padding: 12px 16px;
-        white-space: no-wrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
         font-size: <%= :math.pow(1.2, -1) %>em;
     }
 


### PR DESCRIPTION
Before:
<img width="725" alt="Screenshot 2022-09-30 at 11 14 47" src="https://user-images.githubusercontent.com/792046/193237892-484577ad-efe6-474f-a5f8-ab453b721202.png">

After:
<img width="494" alt="Screenshot 2022-09-30 at 11 17 45" src="https://user-images.githubusercontent.com/792046/193237952-7c8e76dc-a421-4025-a477-1be0e772acde.png">
