### PR TITLE
Add support for protocol upgrades

### DIFF
--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -119,14 +119,14 @@ defmodule Plug.Adapters.Test.Conn do
     :ok
   end
 
-  def upgrade(%{owner: owner, ref: ref} = state, :supported = protocol, opts) do
-    send(owner, {ref, :upgrade, {protocol, opts}})
-    {:ok, state}
-  end
-
   def upgrade(%{owner: owner, ref: ref}, :unsupported = protocol, opts) do
     send(owner, {ref, :upgrade, {protocol, opts}})
     {:error, :not_supported}
+  end
+
+  def upgrade(%{owner: owner, ref: ref} = state, protocol, opts) do
+    send(owner, {ref, :upgrade, {protocol, opts}})
+    {:ok, state}
   end
 
   def push(%{owner: owner, ref: ref}, path, headers) do

--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -119,6 +119,16 @@ defmodule Plug.Adapters.Test.Conn do
     :ok
   end
 
+  def upgrade(%{owner: owner, ref: ref} = state, :supported = protocol, opts) do
+    send(owner, {ref, :upgrade, {protocol, opts}})
+    {:ok, state}
+  end
+
+  def upgrade(%{owner: owner, ref: ref}, :unsupported = protocol, opts) do
+    send(owner, {ref, :upgrade, {protocol, opts}})
+    {:error, :not_supported}
+  end
+
   def push(%{owner: owner, ref: ref}, path, headers) do
     send(owner, {ref, :push, {path, headers}})
     :ok

--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -119,7 +119,7 @@ defmodule Plug.Adapters.Test.Conn do
     :ok
   end
 
-  def upgrade(%{owner: owner, ref: ref}, :unsupported = protocol, opts) do
+  def upgrade(%{owner: owner, ref: ref}, :not_supported = protocol, opts) do
     send(owner, {ref, :upgrade, {protocol, opts}})
     {:error, :not_supported}
   end

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1398,7 +1398,7 @@ defmodule Plug.Conn do
         %{conn | adapter: {adapter, payload}, state: :upgraded}
 
       {:error, :not_supported} ->
-        raise ArgumentError, "upgrade to #{protocol} not supported by #{inspect(adapter)}."
+        raise ArgumentError, "upgrade to #{protocol} not supported by #{inspect(adapter)}"
     end
   end
 

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1391,9 +1391,9 @@ defmodule Plug.Conn do
   normally would in order to indicate an upgrade failure to the client.
   """
   @spec upgrade_adapter(t, atom, term) :: t
-  def upgrade_adapter(%Conn{adapter: {adapter, payload}, state: state} = conn, protocol, opts)
+  def upgrade_adapter(%Conn{adapter: {adapter, payload}, state: state} = conn, protocol, args)
       when state in @unsent do
-    case adapter.upgrade(payload, protocol, opts) do
+    case adapter.upgrade(payload, protocol, args) do
       {:ok, payload} ->
         %{conn | adapter: {adapter, payload}, state: :upgraded}
 
@@ -1402,7 +1402,7 @@ defmodule Plug.Conn do
     end
   end
 
-  def upgrade_adapter(_conn, _protocol, _opts) do
+  def upgrade_adapter(_conn, _protocol, _args) do
     raise AlreadySentError
   end
 

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1367,7 +1367,7 @@ defmodule Plug.Conn do
     do: adapter.inform(payload, status, headers)
 
   @doc """
-  Request a protocol upgrade from the underlying HTTP adapter.
+  Request a protocol upgrade from the underlying adapter.
 
   The precise semantics of an upgrade are deliberately left unspecified here in order to
   support arbitrary upgrades, even to protocols which may not exist today. The primary intent of

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -108,8 +108,8 @@ defmodule Plug.Conn do
   The connection state is used to track the connection lifecycle. It starts as
   `:unset` but is changed to `:set` (via `resp/3`) or `:set_chunked`
   (used only for `before_send` callbacks by `send_chunked/2`) or `:file`
-  (when invoked via `send_file/3`). Its final result is `:sent`, `:file` or
-  `:chunked` depending on the response model.
+  (when invoked via `send_file/3`). Its final result is `:sent`, `:file`, `:chunked` 
+  or `:upgraded` depending on the response model.
 
   ## Private fields
 
@@ -172,7 +172,7 @@ defmodule Plug.Conn do
   @type scheme :: :http | :https
   @type secret_key_base :: binary | nil
   @type segments :: [binary]
-  @type state :: :unset | :set | :set_chunked | :set_file | :file | :chunked | :sent
+  @type state :: :unset | :set | :set_chunked | :set_file | :file | :chunked | :sent | :upgraded
   @type status :: atom | int_status
 
   @type t :: %__MODULE__{
@@ -390,7 +390,7 @@ defmodule Plug.Conn do
   atoms is available in `Plug.Conn.Status`.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent` or `:chunked`.
+  `:sent`, `:chunked` or `:upgraded`.
 
   ## Examples
 
@@ -399,7 +399,10 @@ defmodule Plug.Conn do
 
   """
   @spec put_status(t, status) :: t
-  def put_status(%Conn{state: :sent}, _status), do: raise(AlreadySentError)
+  def put_status(%Conn{state: state}, _status) when state not in @unsent do
+    raise AlreadySentError
+  end
+
   def put_status(%Conn{} = conn, nil), do: %{conn | status: nil}
   def put_status(%Conn{} = conn, status), do: %{conn | status: Plug.Conn.Status.code(status)}
 
@@ -408,7 +411,7 @@ defmodule Plug.Conn do
 
   It expects the connection state to be `:set`, otherwise raises an
   `ArgumentError` for `:unset` connections or a `Plug.Conn.AlreadySentError` for
-  already `:sent` connections.
+  already `:sent`, `:chunked` or `:upgraded` connections.
 
   At the end sets the connection state to `:sent`.
 
@@ -451,7 +454,7 @@ defmodule Plug.Conn do
   If available, the file is sent directly over the socket using
   the operating system `sendfile` operation.
 
-  It expects a connection that has not been `:sent` yet and sets its
+  It expects a connection that has not been `:sent`, `:chunked` or `:upgraded` yet and sets its
   state to `:file` afterwards. Otherwise raises `Plug.Conn.AlreadySentError`.
 
   ## Examples
@@ -494,7 +497,7 @@ defmodule Plug.Conn do
   @doc """
   Sends the response headers as a chunked response.
 
-  It expects a connection that has not been `:sent` yet and sets its
+  It expects a connection that has not been `:sent` or `:upgraded` yet and sets its
   state to `:chunked` afterwards. Otherwise, raises `Plug.Conn.AlreadySentError`.
   After `send_chunked/2` is called, chunks can be sent to the client via
   the `chunk/2` function.
@@ -590,7 +593,7 @@ defmodule Plug.Conn do
   Sets the response to the given `status` and `body`.
 
   It sets the connection state to `:set` (if not already `:set`)
-  and raises `Plug.Conn.AlreadySentError` if it was already `:sent`.
+  and raises `Plug.Conn.AlreadySentError` if it was already `:sent`, `:chunked` or `:upgraded`.
 
   If you also want to send the response, use `send_resp/1` after this
   or use `send_resp/3`.
@@ -674,7 +677,7 @@ defmodule Plug.Conn do
   headers that aren't lowercase will raise a `Plug.Conn.InvalidHeaderError`.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent` or `:chunked`.
+  `:sent`, `:chunked` or `:upgraded`.
 
   ## Examples
 
@@ -684,11 +687,7 @@ defmodule Plug.Conn do
   @spec prepend_req_headers(t, headers) :: t
   def prepend_req_headers(conn, headers)
 
-  def prepend_req_headers(%Conn{state: :sent}, _headers) do
-    raise AlreadySentError
-  end
-
-  def prepend_req_headers(%Conn{state: :chunked}, _headers) do
+  def prepend_req_headers(%Conn{state: state}, _headers) when state not in @unsent do
     raise AlreadySentError
   end
 
@@ -723,11 +722,7 @@ defmodule Plug.Conn do
   @spec merge_req_headers(t, Enum.t()) :: t
   def merge_req_headers(conn, headers)
 
-  def merge_req_headers(%Conn{state: :sent}, _headers) do
-    raise AlreadySentError
-  end
-
-  def merge_req_headers(%Conn{state: :chunked}, _headers) do
+  def merge_req_headers(%Conn{state: state}, _headers) when state not in @unsent do
     raise AlreadySentError
   end
 
@@ -762,7 +757,7 @@ defmodule Plug.Conn do
   headers that aren't lowercase will raise a `Plug.Conn.InvalidHeaderError`.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent` or `:chunked`.
+  `:sent`, `:chunked` or `:upgraded`.
 
   ## Examples
 
@@ -772,7 +767,7 @@ defmodule Plug.Conn do
   @spec put_req_header(t, binary, binary) :: t
   def put_req_header(conn, key, value)
 
-  def put_req_header(%Conn{state: :sent}, _key, _value) do
+  def put_req_header(%Conn{state: state}, _key, _value) when state not in @unsent do
     raise AlreadySentError
   end
 
@@ -786,7 +781,7 @@ defmodule Plug.Conn do
   Deletes a request header if present.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent` or `:chunked`.
+  `:sent`, `:chunked` or `:upgraded`.
 
   ## Examples
 
@@ -796,11 +791,7 @@ defmodule Plug.Conn do
   @spec delete_req_header(t, binary) :: t
   def delete_req_header(conn, key)
 
-  def delete_req_header(%Conn{state: :sent}, _key) do
-    raise AlreadySentError
-  end
-
-  def delete_req_header(%Conn{state: :chunked}, _key) do
+  def delete_req_header(%Conn{state: state}, _key) when state not in @unsent do
     raise AlreadySentError
   end
 
@@ -814,7 +805,7 @@ defmodule Plug.Conn do
   value.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent` or `:chunked`.
+  `:sent`, `:chunked` or `:upgraded`.
 
   Only the first value of the header `key` is updated if present.
 
@@ -831,11 +822,7 @@ defmodule Plug.Conn do
   @spec update_req_header(t, binary, binary, (binary -> binary)) :: t
   def update_req_header(conn, key, initial, fun)
 
-  def update_req_header(%Conn{state: :sent}, _key, _initial, _fun) do
-    raise AlreadySentError
-  end
-
-  def update_req_header(%Conn{state: :chunked}, _key, _initial, _fun) do
+  def update_req_header(%Conn{state: state}, _key, _initial, _fun) when state not in @unsent do
     raise AlreadySentError
   end
 
@@ -875,7 +862,7 @@ defmodule Plug.Conn do
   headers that aren't lowercase will raise a `Plug.Conn.InvalidHeaderError`.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent` or `:chunked`.
+  `:sent`, `:chunked` or `:upgraded`.
 
   Raises a `Plug.Conn.InvalidHeaderError` if the header value contains control
   feed (`\r`) or newline (`\n`) characters.
@@ -886,11 +873,7 @@ defmodule Plug.Conn do
 
   """
   @spec put_resp_header(t, binary, binary) :: t
-  def put_resp_header(%Conn{state: :sent}, _key, _value) do
-    raise AlreadySentError
-  end
-
-  def put_resp_header(%Conn{state: :chunked}, _key, _value) do
+  def put_resp_header(%Conn{state: state}, _key, _value) when state not in @unsent do
     raise AlreadySentError
   end
 
@@ -916,7 +899,7 @@ defmodule Plug.Conn do
   headers that aren't lowercase will raise a `Plug.Conn.InvalidHeaderError`.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent` or `:chunked`.
+  `:sent`, `:chunked` or `:upgraded`.
 
   Raises a `Plug.Conn.InvalidHeaderError` if the header value contains control
   feed (`\r`) or newline (`\n`) characters.
@@ -929,11 +912,7 @@ defmodule Plug.Conn do
   @spec prepend_resp_headers(t, headers) :: t
   def prepend_resp_headers(conn, headers)
 
-  def prepend_resp_headers(%Conn{state: :sent}, _headers) do
-    raise AlreadySentError
-  end
-
-  def prepend_resp_headers(%Conn{state: :chunked}, _headers) do
+  def prepend_resp_headers(%Conn{state: state}, _headers) when state not in @unsent do
     raise AlreadySentError
   end
 
@@ -965,11 +944,7 @@ defmodule Plug.Conn do
   @spec merge_resp_headers(t, Enum.t()) :: t
   def merge_resp_headers(conn, headers)
 
-  def merge_resp_headers(%Conn{state: :sent}, _headers) do
-    raise AlreadySentError
-  end
-
-  def merge_resp_headers(%Conn{state: :chunked}, _headers) do
+  def merge_resp_headers(%Conn{state: state}, _headers) when state not in @unsent do
     raise AlreadySentError
   end
 
@@ -993,7 +968,7 @@ defmodule Plug.Conn do
   Deletes a response header if present.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent` or `:chunked`.
+  `:sent`, `:chunked` or `:upgraded`.
 
   ## Examples
 
@@ -1001,11 +976,7 @@ defmodule Plug.Conn do
 
   """
   @spec delete_resp_header(t, binary) :: t
-  def delete_resp_header(%Conn{state: :sent}, _key) do
-    raise AlreadySentError
-  end
-
-  def delete_resp_header(%Conn{state: :chunked}, _key) do
+  def delete_resp_header(%Conn{state: state}, _key) when state not in @unsent do
     raise AlreadySentError
   end
 
@@ -1019,7 +990,7 @@ defmodule Plug.Conn do
   value.
 
   Raises a `Plug.Conn.AlreadySentError` if the connection has already been
-  `:sent` or `:chunked`.
+  `:sent`, `:chunked` or `:upgraded`.
 
   Only the first value of the header `key` is updated if present.
 
@@ -1036,11 +1007,7 @@ defmodule Plug.Conn do
   @spec update_resp_header(t, binary, binary, (binary -> binary)) :: t
   def update_resp_header(conn, key, initial, fun)
 
-  def update_resp_header(%Conn{state: :sent}, _key, _initial, _fun) do
-    raise AlreadySentError
-  end
-
-  def update_resp_header(%Conn{state: :chunked}, _key, _initial, _fun) do
+  def update_resp_header(%Conn{state: state}, _key, _initial, _fun) when state not in @unsent do
     raise AlreadySentError
   end
 
@@ -1847,8 +1814,10 @@ defmodule Plug.Conn do
     validate_header_value!("set-cookie", cookie)
   end
 
-  defp update_cookies(%Conn{state: :sent}, _fun), do: raise(AlreadySentError)
-  defp update_cookies(%Conn{state: :chunked}, _fun), do: raise(AlreadySentError)
+  defp update_cookies(%Conn{state: state}, _fun) when state not in @unsent do
+    raise AlreadySentError
+  end
+
   defp update_cookies(%Conn{cookies: %Unfetched{}} = conn, _fun), do: conn
   defp update_cookies(%Conn{cookies: cookies} = conn, fun), do: %{conn | cookies: fun.(cookies)}
 

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1382,7 +1382,9 @@ defmodule Plug.Conn do
 
   If the upgrade is accepted by the adapter, the returned `Plug.Conn` will have a `state` of
   `:upgraded`. This state is considered equivalently to a 'sent' state, and is subject to the same
-  limitation on subsequent mutating operations.
+  limitation on subsequent mutating operations. Note that there is no guarantee or expectation
+  that the actual upgrade process is undertaken within this function; it is entirely possible that
+  the server will only do the actual upgrade later in the connection lifecycle.
 
   If the adapter does not support the requested upgrade then this is a noop and the returned 
   `Plug.Conn` will be unchanged. The application can detect this and operate on the conn as it

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1397,8 +1397,8 @@ defmodule Plug.Conn do
       {:ok, payload} ->
         %{conn | adapter: {adapter, payload}, state: :upgraded}
 
-      _ ->
-        conn
+      {:error, :not_supported} ->
+        raise ArgumentError, "upgrade to #{protocol} not supported by #{inspect(adapter)}."
     end
   end
 

--- a/lib/plug/conn/adapter.ex
+++ b/lib/plug/conn/adapter.ex
@@ -134,6 +134,18 @@ defmodule Plug.Conn.Adapter do
               :ok | {:error, term}
 
   @doc """
+  Attempt to upgrade the connection with the client.
+
+  If the adapter does not support the indicated upgrade, then `{:error, :not_supported}` should be
+  be returned.
+
+  If the adapter supports the indicated upgrade but is unable to proceed with it (due to
+  a negotiation error, invalid opts being passed to this function, or some other reason), then an
+  arbitrary error may be returned.
+  """
+  @callback upgrade(payload, protocol :: atom, opts :: term) :: {:ok, payload} | {:error, term}
+
+  @doc """
   Returns peer information such as the address, port and ssl cert.
   """
   @callback get_peer_data(payload) :: peer_data()

--- a/lib/plug/conn/adapter.ex
+++ b/lib/plug/conn/adapter.ex
@@ -141,7 +141,9 @@ defmodule Plug.Conn.Adapter do
 
   If the adapter supports the indicated upgrade but is unable to proceed with it (due to
   a negotiation error, invalid opts being passed to this function, or some other reason), then an
-  arbitrary error may be returned.
+  arbitrary error may be returned. Note that an adapter does not need to process the actual
+  upgrade within this function; it is a wholly supported failure mode for an adapter to attempt
+  the upgrade process later in the connection lifecycle and fail at that point.
   """
   @callback upgrade(payload, protocol :: atom, opts :: term) :: {:ok, payload} | {:error, term}
 

--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -130,6 +130,33 @@ defmodule Plug.Test do
   end
 
   @doc """
+  Returns the upgrade requests that have been sent.
+
+  This function depends on gathering the messages sent by the test adapter when
+  upgrade requests are sent. Calling this function will clear the upgrade request messages from the inbox for the
+  process.
+
+  ## Examples
+
+      conn = conn(:get, "/foo", "bar=10")
+      informs = Plug.Test.send_upgrades(conn)
+      assert {:websocket, [opt: :value]} in informs
+
+  """
+  def sent_upgrades(%Conn{adapter: {Plug.Adapters.Test.Conn, %{ref: ref}}}) do
+    Enum.reverse(receive_upgrades(ref, []))
+  end
+
+  defp receive_upgrades(ref, upgrades) do
+    receive do
+      {^ref, :upgrade, response} ->
+        receive_upgrades(ref, [response | upgrades])
+    after
+      0 -> upgrades
+    end
+  end
+
+  @doc """
   Returns the assets that have been pushed.
 
   This function depends on gathering the messages sent by the test adapter

--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -139,8 +139,8 @@ defmodule Plug.Test do
   ## Examples
 
       conn = conn(:get, "/foo", "bar=10")
-      informs = Plug.Test.send_upgrades(conn)
-      assert {:websocket, [opt: :value]} in informs
+      upgrades = Plug.Test.send_upgrades(conn)
+      assert {:websocket, [opt: :value]} in upgrades
 
   """
   def sent_upgrades(%Conn{adapter: {Plug.Adapters.Test.Conn, %{ref: ref}}}) do

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -126,6 +126,18 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert {103, [{"link", "</script.js>; rel=preload; as=script"}]} in informational_requests
   end
 
+  test "upgrade the upgrade request to the list" do
+    conn =
+      conn(:get, "/")
+      |> Plug.Conn.upgrade_adapter(:unsupported, opt: :unsupported_value)
+      |> Plug.Conn.upgrade_adapter(:supported, opt: :supported_value)
+
+    upgrade_requests = Plug.Test.sent_upgrades(conn)
+
+    assert {:unsupported, [opt: :unsupported_value]} in upgrade_requests
+    assert {:supported, [opt: :supported_value]} in upgrade_requests
+  end
+
   test "full URL overrides existing conn.host" do
     conn_with_host = conn(:get, "http://www.elixir-lang.org/")
     assert conn_with_host.host == "www.elixir-lang.org"

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -126,15 +126,13 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert {103, [{"link", "</script.js>; rel=preload; as=script"}]} in informational_requests
   end
 
-  test "upgrade the upgrade request to the list" do
+  test "upgrade the supported upgrade request to the list" do
     conn =
       conn(:get, "/")
-      |> Plug.Conn.upgrade_adapter(:unsupported, opt: :unsupported_value)
       |> Plug.Conn.upgrade_adapter(:supported, opt: :supported_value)
 
     upgrade_requests = Plug.Test.sent_upgrades(conn)
 
-    assert {:unsupported, [opt: :unsupported_value]} in upgrade_requests
     assert {:supported, [opt: :supported_value]} in upgrade_requests
   end
 

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -462,7 +462,7 @@ defmodule Plug.ConnTest do
   test "upgrade_adapter/3 raises an error on unsupported upgrades" do
     assert_raise(
       ArgumentError,
-      "upgrade to unsupported not supported by Plug.Adapters.Test.Conn.",
+      "upgrade to unsupported not supported by Plug.Adapters.Test.Conn",
       fn ->
         conn(:get, "/foo")
         |> upgrade_adapter(:unsupported, opt: :unsupported)

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -462,10 +462,10 @@ defmodule Plug.ConnTest do
   test "upgrade_adapter/3 raises an error on unsupported upgrades" do
     assert_raise(
       ArgumentError,
-      "upgrade to unsupported not supported by Plug.Adapters.Test.Conn",
+      "upgrade to not_supported not supported by Plug.Adapters.Test.Conn",
       fn ->
         conn(:get, "/foo")
-        |> upgrade_adapter(:unsupported, opt: :unsupported)
+        |> upgrade_adapter(:not_supported, opt: :not_supported)
       end
     )
   end

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -449,6 +449,29 @@ defmodule Plug.ConnTest do
     )
   end
 
+  test "upgrade_adapter/3 requests an upgrade" do
+    conn = conn(:get, "/foo") |> upgrade_adapter(:supported, opt: :supported)
+    assert {:supported, [opt: :supported]} in sent_upgrades(conn)
+  end
+
+  test "upgrade_adapter/3 sets the connection to :upgraded for supported upgrades" do
+    conn = conn(:get, "/foo") |> upgrade_adapter(:supported, opt: :supported)
+    assert conn.state == :upgraded
+  end
+
+  test "upgrade_adapter/3 does not set the connection to :upgraded for failed upgrades" do
+    conn = conn(:get, "/foo") |> upgrade_adapter(:unsupported, opt: :unsupported)
+    assert conn.state == :unset
+  end
+
+  test "upgrade_adapter/3 will raise if the response is sent before upgrading" do
+    assert_raise(Plug.Conn.AlreadySentError, fn ->
+      conn(:get, "/foo")
+      |> send_chunked(200)
+      |> upgrade_adapter(:supported, opt: :supported)
+    end)
+  end
+
   test "chunk/2 raises if send_chunked/3 hasn't been called yet" do
     conn = conn(:get, "/")
 

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -459,9 +459,15 @@ defmodule Plug.ConnTest do
     assert conn.state == :upgraded
   end
 
-  test "upgrade_adapter/3 does not set the connection to :upgraded for failed upgrades" do
-    conn = conn(:get, "/foo") |> upgrade_adapter(:unsupported, opt: :unsupported)
-    assert conn.state == :unset
+  test "upgrade_adapter/3 raises an error on unsupported upgrades" do
+    assert_raise(
+      ArgumentError,
+      "upgrade to unsupported not supported by Plug.Adapters.Test.Conn.",
+      fn ->
+        conn(:get, "/foo")
+        |> upgrade_adapter(:unsupported, opt: :unsupported)
+      end
+    )
   end
 
   test "upgrade_adapter/3 will raise if the response is sent before upgrading" do


### PR DESCRIPTION
This PR is the first step on the road to overhauling how WebSocket server support is exposed to & used by Plug-based applications such as Phoenix (see https://github.com/phoenixframework/phoenix/issues/5003 for background). 

Support is added here for a new `Plug.Conn.upgrade_adapter/3` function, and a backing `Plug.Conn.Adapter.upgrade/3` callback. The intent of this PR is solely to provide the minimal plumbing necessary for Plug applications to be able to request a protocol upgrade from the underlying web server; beyond this minimum plumbing no requirements are put on the upgrade process, supported protocols, or how a Plug application is expected to determine if a connection is suitable for upgrading.

This PR represents the total extent of changes expected to the Plug API as a result of the work laid out in the linked issue above, and can be reviewed & merged as-is, or kept open & considered as part of the overall workup; it's up to you.

Companion PRs for this are at https://github.com/elixir-plug/plug_cowboy/pull/88 and https://github.com/mtrudel/bandit/pull/38.