### PR TITLE
Fix header validation

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -890,7 +890,7 @@ defmodule Plug.Conn do
 
   def put_resp_header(%Conn{adapter: adapter, resp_headers: headers} = conn, key, value)
       when is_binary(key) and is_binary(value) do
-    validate_header_key_normalied_if_test!(adapter, key)
+    validate_header_key_normalized_if_test!(adapter, key)
     validate_header_key_value!(key, value)
     %{conn | resp_headers: List.keystore(headers, key, 0, {key, value})}
   end
@@ -930,7 +930,7 @@ defmodule Plug.Conn do
   def prepend_resp_headers(%Conn{adapter: adapter, resp_headers: resp_headers} = conn, headers)
       when is_list(headers) do
     for {key, value} <- headers do
-      validate_header_key_normalied_if_test!(adapter, key)
+      validate_header_key_normalized_if_test!(adapter, key)
       validate_header_key_value!(key, value)
     end
 
@@ -967,7 +967,7 @@ defmodule Plug.Conn do
     headers =
       Enum.reduce(headers, current, fn {key, value}, acc
                                        when is_binary(key) and is_binary(value) ->
-        validate_header_key_normalied_if_test!(adapter, key)
+        validate_header_key_normalized_if_test!(adapter, key)
         validate_header_key_value!(key, value)
         List.keystore(acc, key, 0, {key, value})
       end)
@@ -1893,16 +1893,16 @@ defmodule Plug.Conn do
   end
 
   defp validate_req_header!(adapter, key),
-    do: validate_header_key_normalied_if_test!(adapter, key)
+    do: validate_header_key_normalized_if_test!(adapter, key)
 
-  defp validate_header_key_normalied_if_test!({Plug.Adapters.Test.Conn, _}, key) do
+  defp validate_header_key_normalized_if_test!({Plug.Adapters.Test.Conn, _}, key) do
     if Application.fetch_env!(:plug, :validate_header_keys_during_test) and
          not normalized_header_key?(key) do
       raise InvalidHeaderError, "header key is not lowercase: " <> inspect(key)
     end
   end
 
-  defp validate_header_key_normalied_if_test!(_adapter, _key) do
+  defp validate_header_key_normalized_if_test!(_adapter, _key) do
     :ok
   end
 

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1913,20 +1913,20 @@ defmodule Plug.Conn do
   defp normalized_header_key?(_), do: false
 
   defp validate_header_key_value!(key, value) do
-    case :binary.match(key, [":", "\n", "\r"]) do
+    case :binary.match(key, [":", "\n", "\r", "\x00"]) do
       {_, _} ->
         raise InvalidHeaderError,
-              "header #{inspect(key)} contains a control feed (\\r), colon(:) or newline character"
+              "header #{inspect(key)} contains a control feed (\\r), colon (:), newline (\\n) or null (\\x00)"
 
       :nomatch ->
         key
     end
 
-    case :binary.match(value, ["\n", "\r"]) do
+    case :binary.match(value, ["\n", "\r", "\x00"]) do
       {_, _} ->
         raise InvalidHeaderError,
-              "value for header #{inspect(key)} contains control feed (\\r) or newline " <>
-                "(\\n): #{inspect(value)}"
+              "value for header #{inspect(key)} contains control feed (\\r), newline (\\n) or null (\\x00)" <>
+                ": #{inspect(value)}"
 
       :nomatch ->
         value

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -530,7 +530,7 @@ defmodule Plug.ConnTest do
     conn = conn(:get, "/foo")
 
     assert_raise Plug.Conn.InvalidHeaderError,
-                 ~S[header "foo\r" contains a control feed (\r), colon(:) or newline character],
+                 ~S[header "foo\r" contains a control feed (\r), colon (:), newline (\n) or null (\x00)],
                  fn ->
                    put_resp_header(conn, "foo\r", "bar")
                  end
@@ -541,7 +541,7 @@ defmodule Plug.ConnTest do
     conn = conn(:get, "/foo")
 
     assert_raise Plug.Conn.InvalidHeaderError,
-                 ~S[header "foo\r" contains a control feed (\r), colon(:) or newline character],
+                 ~S[header "foo\r" contains a control feed (\r), colon (:), newline (\n) or null (\x00)],
                  fn ->
                    put_resp_header(conn, "foo\r", "bar")
                  end
@@ -549,14 +549,14 @@ defmodule Plug.ConnTest do
 
   test "put_resp_header/3 raises when invalid header value given" do
     message =
-      ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\rBAR"]
+      ~S[value for header "x-sample" contains control feed (\r), newline (\n) or null (\x00): "value\rBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
       put_resp_header(conn(:get, "/foo"), "x-sample", "value\rBAR")
     end
 
     message =
-      ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\n\nBAR"]
+      ~S[value for header "x-sample" contains control feed (\r), newline (\n) or null (\x00): "value\n\nBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
       put_resp_header(conn(:get, "/foo"), "x-sample", "value\n\nBAR")
@@ -603,14 +603,14 @@ defmodule Plug.ConnTest do
 
   test "prepend_resp_headers/2 raises when invalid header value given" do
     message =
-      ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\rBAR"]
+      ~S[value for header "x-sample" contains control feed (\r), newline (\n) or null (\x00): "value\rBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
       prepend_resp_headers(conn(:get, "/foo"), [{"x-sample", "value\rBAR"}])
     end
 
     message =
-      ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\n\nBAR"]
+      ~S[value for header "x-sample" contains control feed (\r), newline (\n) or null (\x00): "value\n\nBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
       prepend_resp_headers(conn(:get, "/foo"), [{"x-sample", "value\n\nBAR"}])
@@ -622,7 +622,7 @@ defmodule Plug.ConnTest do
     conn = conn(:get, "/foo")
 
     assert_raise Plug.Conn.InvalidHeaderError,
-                 ~S[header "foo\n" contains a control feed (\r), colon(:) or newline character],
+                 ~S[header "foo\n" contains a control feed (\r), colon (:), newline (\n) or null (\x00)],
                  fn ->
                    prepend_resp_headers(conn, [{"foo\n", "bar"}])
                  end
@@ -633,7 +633,7 @@ defmodule Plug.ConnTest do
     conn = conn(:get, "/foo")
 
     assert_raise Plug.Conn.InvalidHeaderError,
-                 ~S[header "foo\r" contains a control feed (\r), colon(:) or newline character],
+                 ~S[header "foo\n" contains a control feed (\r), colon (:), newline (\n) or null (\x00)],
                  fn ->
                    prepend_resp_headers(conn, [{"foo\n", "bar"}])
                  end
@@ -641,14 +641,14 @@ defmodule Plug.ConnTest do
 
   test "merge_resp_headers/3 raises when invalid header value given" do
     message =
-      ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\rBAR"]
+      ~S[value for header "x-sample" contains control feed (\r), newline (\n) or null (\x00): "value\rBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
       merge_resp_headers(conn(:get, "/foo"), [{"x-sample", "value\rBAR"}])
     end
 
     message =
-      ~S[value for header "x-sample" contains control feed (\r) or newline (\n): "value\n\nBAR"]
+      ~S[value for header "x-sample" contains control feed (\r), newline (\n) or null (\x00): "value\n\nBAR"]
 
     assert_raise Plug.Conn.InvalidHeaderError, message, fn ->
       merge_resp_headers(conn(:get, "/foo"), [{"x-sample", "value\n\nBAR"}])


### PR DESCRIPTION
This PR fixes 2 issues with headers:
- Lack of any validation on the header key, leading to http header injection
- Allowing null bytes in http headers, which get rejected by most clients(libcurl, chromium, firefox)