### PR TITLE
Proposal - Pretty print error structs in debugger page

### DIFF
--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -186,7 +186,7 @@ defmodule Plug.Debugger do
   def render(conn, status, kind, reason, stack, opts) do
     session = maybe_fetch_session(conn)
     params = maybe_fetch_query_params(conn)
-    {title, message, pretty} = info(kind, reason)
+    {title, message} = info(kind, reason)
     [headline | details] = String.split(message, "\n\n")
 
     assigns = [
@@ -216,7 +216,6 @@ defmodule Plug.Debugger do
           conn: conn,
           headline: headline,
           details: details,
-          pretty: pretty,
           markdown: markdown,
           style: style,
           banner: banner,
@@ -307,15 +306,9 @@ defmodule Plug.Debugger do
   defp status(:error, error), do: Plug.Exception.status(error)
   defp status(_, _), do: 500
 
-  defp info(:error, %KeyError{key: key, term: term} = error) when not is_nil(term) do
-    message = "key #{inspect(key)} not found in: %" <> inspect(term.__struct__) <> "{...}"
-    pretty = inspect(term, pretty: true, limit: :infinity)
-    {inspect(error.__struct__), message, pretty}
-  end
-
-  defp info(:error, error), do: {inspect(error.__struct__), Exception.message(error), nil}
-  defp info(:throw, thrown), do: {"unhandled throw", inspect(thrown), nil}
-  defp info(:exit, reason), do: {"unhandled exit", Exception.format_exit(reason), nil}
+  defp info(:error, error), do: {inspect(error.__struct__), Exception.message(error)}
+  defp info(:throw, thrown), do: {"unhandled throw", inspect(thrown)}
+  defp info(:exit, reason), do: {"unhandled exit", Exception.format_exit(reason)}
 
   defp frames(renderer, stacktrace, opts) do
     app = opts[:otp_app]

--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -187,7 +187,6 @@ defmodule Plug.Debugger do
     session = maybe_fetch_session(conn)
     params = maybe_fetch_query_params(conn)
     {title, message} = info(kind, reason)
-    [headline | details] = String.split(message, "\n\n")
 
     assigns = [
       conn: conn,
@@ -214,8 +213,7 @@ defmodule Plug.Debugger do
       assigns =
         Keyword.merge(assigns,
           conn: conn,
-          headline: headline,
-          details: details,
+          message: message,
           markdown: markdown,
           style: style,
           banner: banner,

--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -707,14 +707,16 @@
         <% end %>
 
         <header class="exception-info">
-            <% [headline | details] = String.split(@message, "\n\n") %>
             <h5 class="struct">
                 <%= h @title %>
                 <small>at <%= h method(@conn) %></small>
                 <small class="path"><%= h @conn.request_path %></small>
             </h5>
-            <h1 class="title"><%= h headline %></h1>
-            <%= for detail <- details do %>
+            <h1 class="title"><%= h @headline %></h1>
+            <%= if @pretty do %>
+            <p class="code-quote"><pre><%= h @pretty %></pre></p>
+            <% end %>
+            <%= for detail <- @details do %>
             <p class="detail"><%= h detail %></p>
             <% end %>
         </header>

--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -128,7 +128,7 @@
     }
 
     .exception-info > .struct,
-    .exception-info > .title,
+    .exception-info > .headline,
     .exception-info > .detail {
         margin: 0;
         padding: 0;
@@ -146,22 +146,22 @@
         font-weight: 400;
     }
 
-    .exception-info > .title {
-        font-size: <%= :math.pow(1.2, 4) %>em;
+    .exception-info > .headline {
+        font-size: <%= :math.pow(1.15, 4) %>em;
         line-height: 1.4;
         font-weight: 300;
         color: <%= @style.primary %>;
     }
 
     @media (max-width: 768px) {
-        .exception-info > .title {
-            font-size: <%= :math.pow(1.15, 4) %>em;
+        .exception-info > .headline {
+            font-size: <%= :math.pow(1.1, 4) %>em;
         }
     }
 
     @media (max-width: 480px) {
-        .exception-info > .title {
-            font-size: <%= :math.pow(1.1, 4) %>em;
+        .exception-info > .headline {
+            font-size: <%= :math.pow(1.05, 4) %>em;
         }
     }
 
@@ -712,10 +712,7 @@
                 <small>at <%= h method(@conn) %></small>
                 <small class="path"><%= h @conn.request_path %></small>
             </h5>
-            <h1 class="title"><%= h @headline %></h1>
-            <%= if @pretty do %>
-            <p class="code-quote"><pre><%= h @pretty %></pre></p>
-            <% end %>
+            <code class="headline"><pre><%= h @headline %></pre></code>
             <%= for detail <- @details do %>
             <p class="detail"><%= h detail %></p>
             <% end %>

--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -127,8 +127,7 @@
         }
     }
 
-    .exception-info > .struct,
-    .exception-info > .detail {
+    .exception-info > .struct {
         margin: 0;
         padding: 0;
     }
@@ -145,9 +144,8 @@
         font-weight: 400;
     }
 
-    .exception-info > .detail {
-        margin-top: 1.3em;
-        white-space: pre-wrap;
+    .exception-info > code {
+        line-height: 1.5;
     }
 
     /*
@@ -692,10 +690,7 @@
                 <small>at <%= h method(@conn) %></small>
                 <small class="path"><%= h @conn.request_path %></small>
             </h5>
-            <code><pre><%= h @headline %></pre></code>
-            <%= for detail <- @details do %>
-            <p class="detail"><%= h detail %></p>
-            <% end %>
+            <code><pre><%= h @message %></pre></code>
         </header>
 
         <%= for %{label: label, encoded_handler: encoded_handler} <- @actions do %>

--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -128,7 +128,6 @@
     }
 
     .exception-info > .struct,
-    .exception-info > .headline,
     .exception-info > .detail {
         margin: 0;
         padding: 0;
@@ -144,25 +143,6 @@
         font-size: 1em;
         color: <%= @style.accent %>;
         font-weight: 400;
-    }
-
-    .exception-info > .headline {
-        font-size: <%= :math.pow(1.15, 4) %>em;
-        line-height: 1.4;
-        font-weight: 300;
-        color: <%= @style.primary %>;
-    }
-
-    @media (max-width: 768px) {
-        .exception-info > .headline {
-            font-size: <%= :math.pow(1.1, 4) %>em;
-        }
-    }
-
-    @media (max-width: 480px) {
-        .exception-info > .headline {
-            font-size: <%= :math.pow(1.05, 4) %>em;
-        }
     }
 
     .exception-info > .detail {
@@ -712,7 +692,7 @@
                 <small>at <%= h method(@conn) %></small>
                 <small class="path"><%= h @conn.request_path %></small>
             </h5>
-            <code class="headline"><pre><%= h @headline %></pre></code>
+            <code><pre><%= h @headline %></pre></code>
             <%= for detail <- @details do %>
             <p class="detail"><%= h detail %></p>
             <% end %>


### PR DESCRIPTION
I couldn't find such proposal in past issues/PRs so this one is a simple PoC to gather feedback if that's a good idea or not.

In short, currently the debugger page looks like this:

<img width="992" alt="Screenshot 2023-01-06 at 1 53 48 PM" src="https://user-images.githubusercontent.com/36407/211080346-3c0c6579-3a63-438a-92d2-131d0db38e1f.png">

And the idea is to improve UX by displaying this:


<img width="991" alt="Screenshot 2023-01-06 at 1 53 20 PM" src="https://user-images.githubusercontent.com/36407/211080507-979b9676-c864-4ddd-b5a4-9ca48f2668f0.png">

Notes:
- It may get too long so a toggle link to show/hide details could help
- Pattern matching the error to pretty inspect it instead of calling `Exception.message/1` seems okay to deal with some exceptions but it could get out of sync with Elixir stdlib if wording changes.