### PR TITLE
Clarify that max-age is not set by default

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1590,7 +1590,8 @@ defmodule Plug.Conn do
 
     * `:domain` - the domain the cookie applies to
     * `:max_age` - the cookie max-age, in seconds. Providing a value for this
-      option will set both the _max-age_ and _expires_ cookie attributes.
+      option will set both the _max-age_ and _expires_ cookie attributes. Unset
+      by default, which means the browser will default to a [session cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_the_lifetime_of_a_cookie).
     * `:path` - the path the cookie applies to
     * `:http_only` - when `false`, the cookie is accessible beyond HTTP
     * `:secure` - if the cookie must be sent only over https. Defaults


### PR DESCRIPTION
I was a bit confused by this statement:

> By default a signed or encrypted cookie is only valid for a day, unless a `:max_age` is specified.

On investigation, this is talking about the validity of the signature, not of the cookie itself. I attempted to clarify that `:max_age` _of the cookie_ is unset by default, which produces a session cookie.

<img width="825" alt="image" src="https://user-images.githubusercontent.com/498229/213655665-d50ef3dc-c4d4-4cba-8efa-32402e713b12.png">
