### PR TITLE
Fix Plug.Conn.Status.reason_phrase/1 error message

### DIFF
--- a/lib/plug/conn/status.ex
+++ b/lib/plug/conn/status.ex
@@ -166,7 +166,7 @@ defmodule Plug.Conn.Status do
         MIX_ENV=dev mix deps.clean plug --build
 
     Doing this will allow the use of the integer status code 998 as
-    well as the atom :unavailable_for_legal_reasons in many Plug functions.
+    well as the atom :not_an_rfc_status_code in many Plug functions.
     For example:
 
         put_status(conn, :not_an_rfc_status_code)


### PR DESCRIPTION
When `Plug.Conn.Status.reason_phrase/1` is called with an error code not defined by Plug or via configuration, the message of the ArgumentError that's raised references the atom `:unavailable_for_legal_reasons`. According to the example code above and below the text, it should instead reference `:not_an_rfc_status_code`.

Here's hoping `HTTP 998 Not An RFC Status Code` is never proposed 😆 

I hope this typo PR isn't too noisy—it seems worthwhile to correct the confusing error message.