### PR TITLE
Allow passing :sign and :encrypt keys in cookie session plug

### DIFF
--- a/lib/plug/session.ex
+++ b/lib/plug/session.ex
@@ -34,6 +34,8 @@ defmodule Plug.Session do
     * `:http_only` - see `Plug.Conn.put_resp_cookie/4`;
     * `:same_site` - see `Plug.Conn.put_resp_cookie/4`;
     * `:extra` - see `Plug.Conn.put_resp_cookie/4`;
+    * `:sign` - see `Plug.Conn.put_resp_cookie/4`;
+    * `:encrypt` - see `Plug.Conn.put_resp_cookie/4`;
 
   Additional options can be given to the session store, see the store's
   documentation for the options it accepts.
@@ -46,7 +48,7 @@ defmodule Plug.Session do
   alias Plug.Conn
   @behaviour Plug
 
-  @cookie_opts [:domain, :max_age, :path, :secure, :http_only, :extra, :same_site]
+  @cookie_opts [:domain, :max_age, :path, :secure, :http_only, :extra, :same_site, :sign, :encrypt]
 
   @impl true
   def init(opts) do

--- a/test/plug/csrf_protection_test.exs
+++ b/test/plug/csrf_protection_test.exs
@@ -10,8 +10,7 @@ defmodule Plug.CSRFProtectionTest do
                   store: :cookie,
                   key: "foobar",
                   encryption_salt: "cookie store encryption salt",
-                  signing_salt: "cookie store signing salt",
-                  encrypt: true
+                  signing_salt: "cookie store signing salt"
                 )
 
   @secret String.duplicate("abcdef0123456789", 8)


### PR DESCRIPTION
We don't have a way to sign or encrypt a cookie token when working with sessions via `Plug.Session` and `Plug.Conn.put_session/3`. When we generate a cookie with aforementioned mechanisms, we get a token that is not validated. The flags for the cookie are set correctly, but if a client has an ability to save the token (it's pretty easy if it's not a browser), these flags take no real effect, as the client can just pass the token and get permanent access.

This may be bypassed by using `Plug.Conn.put_resp_cookie/4`, but it's not that convenient because we have to pass the same options (like `:max_age`) in two places.

So, this PR enables us to pass `:sign` and `:encrypt` options from plug's options to `Plug.Conn.put_resp_cookie/4` (which is called under the hood).