### PR TITLE
Add option for calling Plug.Session with MFA for runtime config

### DIFF
--- a/lib/plug/session.ex
+++ b/lib/plug/session.ex
@@ -36,7 +36,8 @@ defmodule Plug.Session do
     * `:extra` - see `Plug.Conn.put_resp_cookie/4`;
 
   Additional options can be given to the session store, see the store's
-  documentation for the options it accepts.
+  documentation for the options it accepts. It can also accept a MFA to
+  allow loading config in runtime `{MyAppWeb.Auth, :get_session_config, []}`.
 
   ## Examples
 
@@ -47,6 +48,9 @@ defmodule Plug.Session do
   @behaviour Plug
 
   @cookie_opts [:domain, :max_age, :path, :secure, :http_only, :extra, :same_site]
+
+  @impl true
+  def init({module, func, args}), do: apply(module, func, args) |> init()
 
   @impl true
   def init(opts) do

--- a/test/plug/session_test.exs
+++ b/test/plug/session_test.exs
@@ -197,4 +197,21 @@ defmodule Plug.SessionTest do
     assert get_session(conn, :other) == "other"
     assert get_session(conn, :bar) == "bar"
   end
+
+  test "allows MFA for passing session options" do
+    opts = Plug.Session.init({__MODULE__, :session_opts, ["foobar"]})
+
+    assert opts.key == "foobar"
+    assert opts.cookie_opts[:secure] == true
+  end
+
+  def session_opts(key) do
+    [
+      store: ProcessStore,
+      key: key,
+      secure: true,
+      path: "some/path",
+      extra: "extra"
+    ]
+  end
 end


### PR DESCRIPTION
This allows the session and cookie options to be dynamically configured during runtime, which is already supported in the [websocket options](https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#socket/3-connect-info) of `Phoenix.Endpoint` but not supported here. My main use case was setting `secure: true` in production if using HTTPS behind SSL termination (so it's not automatically set). Example usage:

```elixir
config :my_app, :session,
  store: :cookie,
  key: "_my_app_session",
  signing_salt: "12345",
  same_site: "Lax"
```

```elixir
socket "/live", Phoenix.LiveView.Socket,
  websocket: [
    connect_info: [session: {Application, :fetch_env!, [:my_app, :session]}]
  ]

plug Plug.Session, {Application, :fetch_env!, [:my_app, :session]}
```