### PR TITLE
Fix code examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ defmodule MyPlug do
   end
 end
 
+defmodule Router do
+  use Plug.Router
+
+  plug Plug.Logger
+  plug :match
+  plug :dispatch
+
+  forward "/", to: MyPlug
+end
+
 require Logger
 webserver = {Plug.Cowboy, plug: Router, scheme: :http, port: 4000}
 {:ok, _} = Supervisor.start_link([webserver], strategy: :one_for_one)
@@ -77,8 +87,8 @@ routes, we will use the built-in `Plug.Router` for that:
 Mix.install([:plug, :bandit, :websock_adapter])
 
 defmodule EchoServer do
-  def init(args) do
-    {:ok, []}
+  def init(options) do
+    {:ok, options}
   end
 
   def handle_in({"ping", [opcode: :text]}, state) do
@@ -119,7 +129,7 @@ defmodule Router do
 end
 
 require Logger
-webserver = {Bandit, plug: Router, scheme: :http, port: 4000}
+webserver = {Bandit, plug: Router, scheme: :http, options: [port: 4000]}
 {:ok, _} = Supervisor.start_link([webserver], strategy: :one_for_one)
 Logger.info("Plug now running on localhost:4000")
 ```

--- a/README.md
+++ b/README.md
@@ -57,18 +57,8 @@ defmodule MyPlug do
   end
 end
 
-defmodule Router do
-  use Plug.Router
-
-  plug Plug.Logger
-  plug :match
-  plug :dispatch
-
-  forward "/", to: MyPlug
-end
-
 require Logger
-webserver = {Plug.Cowboy, plug: Router, scheme: :http, port: 4000}
+webserver = {Plug.Cowboy, plug: MyPlug, scheme: :http, port: 4000}
 {:ok, _} = Supervisor.start_link([webserver], strategy: :one_for_one)
 Logger.info("Plug now running on localhost:4000")
 ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ defmodule MyPlug do
 end
 
 require Logger
-webserver = {Plug.Cowboy, plug: MyPlug, scheme: :http, port: 4000}
+webserver = {Plug.Cowboy, plug: MyPlug, scheme: :http, options: [port: 4000]}
 {:ok, _} = Supervisor.start_link([webserver], strategy: :one_for_one)
 Logger.info("Plug now running on localhost:4000")
 ```


### PR DESCRIPTION
Fixing a few issues in the examples in the README file.

1. For Bandit `:port` is not a top-level config. I see that in `Plug.Cowboy` there is a comment `We support :options for backwards compatibility`, so maybe the intent is to migrate away from `:options`? But this is still not supported in `Bandit`, so copy-pasting the example in `iex` leads to errors at the moment.

2. In the `Plug.Cowboy` example the `Router` module was missing. 

3. Fix an unused parameter in the `init/1` function in the Bandit+websocket example.