### PR TITLE
Updated SSL/TLS defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.10.4
-              otp: 21.3
+              elixir: 1.12.3
+              otp: 22.3
           - pair:
-              elixir: 1.13.3
-              otp: 24.2.1
+              elixir: 1.14.4
+              otp: 25.3
             lint: lint
     steps:
       - uses: actions/checkout@v2

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -129,7 +129,7 @@ defmodule Plug.SSL do
   [Mozilla Security/Server Side TLS](https://wiki.mozilla.org/Security/Server_Side_TLS)
 
   The **Strong** cipher suite only supports tlsv1.3. Ciphers were based on the "Modern"
-  configuration recommandation and support forward secrecy and are authenticated.
+  configuration recommendation and support forward secrecy and are authenticated.
   The intention of this configuration is to provide as secure as possible defaults
   knowing that it will not be fully compatible with older browsers and operating systems.
 

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -148,8 +148,8 @@ defmodule Plug.SSL do
     |> validate_ciphers()
     |> normalize_ssl_files()
     |> convert_to_charlist()
-    |> set_secure_defaults()
     |> configure_managed_tls()
+    |> set_secure_defaults()
   catch
     {:configure, message} -> {:error, message}
   else

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Plug.MixProject do
     [
       app: :plug,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.12",
       deps: deps(),
       package: package(),
       description: @description,

--- a/test/plug/ssl_test.exs
+++ b/test/plug/ssl_test.exs
@@ -29,15 +29,12 @@ defmodule Plug.SSLTest do
       assert opts[:cipher_suite] == nil
       assert opts[:honor_cipher_order] == true
       assert opts[:eccs] == [:secp256r1, :secp384r1, :secp521r1]
-      assert opts[:versions] == [:"tlsv1.2"]
+      assert opts[:versions] == [:"tlsv1.3"]
 
       assert opts[:ciphers] == [
-               ~c"ECDHE-RSA-AES256-GCM-SHA384",
-               ~c"ECDHE-ECDSA-AES256-GCM-SHA384",
-               ~c"ECDHE-RSA-AES128-GCM-SHA256",
-               ~c"ECDHE-ECDSA-AES128-GCM-SHA256",
-               ~c"DHE-RSA-AES256-GCM-SHA384",
-               ~c"DHE-RSA-AES128-GCM-SHA256"
+               ~c"TLS_AES_128_GCM_SHA256",
+               ~c"TLS_AES_256_GCM_SHA384",
+               ~c"TLS_CHACHA20_POLY1305_SHA256"
              ]
     end
 
@@ -46,25 +43,20 @@ defmodule Plug.SSLTest do
       assert opts[:cipher_suite] == nil
       assert opts[:honor_cipher_order] == true
       assert opts[:eccs] == [:secp256r1, :secp384r1, :secp521r1]
-      assert opts[:versions] == [:"tlsv1.2", :"tlsv1.1", :tlsv1]
+      assert opts[:versions] == [:"tlsv1.3", :"tlsv1.2"]
 
       assert opts[:ciphers] == [
-               ~c"ECDHE-RSA-AES256-GCM-SHA384",
-               ~c"ECDHE-ECDSA-AES256-GCM-SHA384",
-               ~c"ECDHE-RSA-AES128-GCM-SHA256",
+               ~c"TLS_AES_128_GCM_SHA256",
+               ~c"TLS_AES_256_GCM_SHA384",
+               ~c"TLS_CHACHA20_POLY1305_SHA256",
                ~c"ECDHE-ECDSA-AES128-GCM-SHA256",
-               ~c"DHE-RSA-AES256-GCM-SHA384",
+               ~c"ECDHE-RSA-AES128-GCM-SHA256",
+               ~c"ECDHE-ECDSA-AES256-GCM-SHA384",
+               ~c"ECDHE-RSA-AES256-GCM-SHA384",
+               ~c"ECDHE-ECDSA-CHACHA20-POLY1305",
+               ~c"ECDHE-RSA-CHACHA20-POLY1305",
                ~c"DHE-RSA-AES128-GCM-SHA256",
-               ~c"ECDHE-RSA-AES256-SHA384",
-               ~c"ECDHE-ECDSA-AES256-SHA384",
-               ~c"ECDHE-RSA-AES128-SHA256",
-               ~c"ECDHE-ECDSA-AES128-SHA256",
-               ~c"DHE-RSA-AES256-SHA256",
-               ~c"DHE-RSA-AES128-SHA256",
-               ~c"ECDHE-RSA-AES256-SHA",
-               ~c"ECDHE-ECDSA-AES256-SHA",
-               ~c"ECDHE-RSA-AES128-SHA",
-               ~c"ECDHE-ECDSA-AES128-SHA"
+               ~c"DHE-RSA-AES256-GCM-SHA384"
              ]
     end
 


### PR DESCRIPTION
This updates the default SSL/TLS configurations according to [Mozillas Server Side TLS Guidelines](https://wiki.mozilla.org/Security/Server_Side_TLS).

The last update of the configuration was in 2018 and didn't support TLS 1.3.

Since support for TLS 1.3 was added in OTP 22, I also bumped the Elixir version to 1.12 (since it was the first version requiring OTP 22).
