### PR TITLE
Add `get_session/3` to allow providing default value

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1685,15 +1685,17 @@ defmodule Plug.Conn do
   end
 
   @doc """
-  Returns session value for the given `key`. If `key`
-  is not set, `nil` is returned.
+  Returns session value for the given `key`. 
+
+  Returns the `default` value if `key` does not exist.
+  If `default` is not provided, `nil` is used.
 
   The key can be a string or an atom, where atoms are
   automatically converted to strings.
   """
-  @spec get_session(t, String.t() | atom) :: any
-  def get_session(conn, key) when is_atom(key) or is_binary(key) do
-    conn |> get_session |> Map.get(session_key(key))
+  @spec get_session(t, String.t() | atom, any) :: any
+  def get_session(conn, key, default \\ nil) when is_atom(key) or is_binary(key) do
+    conn |> get_session |> Map.get(session_key(key), default)
   end
 
   @doc """

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -1263,6 +1263,7 @@ defmodule Plug.ConnTest do
 
     conn = put_session(conn, "foo", :bar)
     conn = put_session(conn, :key, 42)
+    conn = put_session(conn, "is_nil", nil)
 
     assert conn.private[:plug_session_info] == :write
 
@@ -1272,6 +1273,11 @@ defmodule Plug.ConnTest do
     assert get_session(conn, "foo") == :bar
     assert get_session(conn, "key") == 42
     assert get_session(conn, "unknown") == nil
+
+    assert get_session(conn, "unknown", nil) == nil
+    assert get_session(conn, "unknown", true) == true
+    assert get_session(conn, :unknown, 42) == 42
+    assert get_session(conn, "is_nil", 42) == nil
 
     conn = %{conn | state: :sent}
 


### PR DESCRIPTION
Hello!

While pairing on a project we found a need to set a default value for a session option and realized that `get_session/3` doesn't exist.
This allows us to set a default value when attempting to `get_session` when the value is `nil`.

### Alternatives
Currently this returns the `default` value even if the `key` exists but contains `nil`.
An alternative implementation would check if the `key` exists in the session and only return `nil` if the key does not exist.

Let us know what you think, thanks!
