### PR TITLE
Wrong port option in Bandit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ defmodule Router do
 end
 
 require Logger
-webserver = {Bandit, plug: Router, scheme: :http, options: [port: 4000]}
+webserver = {Bandit, plug: Router, scheme: :http, port: 4000}
 {:ok, _} = Supervisor.start_link([webserver], strategy: :one_for_one)
 Logger.info("Plug now running on localhost:4000")
 Process.sleep(:infinity)


### PR DESCRIPTION
The way to define the 'port:' option was not correct.