### PR TITLE
Add documentation for `Plug.Conn.Query.encode/2` for list of maps

### DIFF
--- a/lib/plug/conn/query.ex
+++ b/lib/plug/conn/query.ex
@@ -56,7 +56,7 @@ defmodule Plug.Conn.Query do
       iex> encode(%{foo: %{bar: "baz"}})
       "foo[bar]=baz"
 
-  It is not possible to encode maps inside lists, if the maps have 0 or more than 1 element.
+  It is only possible to encode maps inside lists if those maps have exactly one element.
   In this case it is possible to encode the parameters using maps instead of lists:
 
       iex> encode(%{"list" => [%{"a" => 1, "b" => 2}]})

--- a/lib/plug/conn/query.ex
+++ b/lib/plug/conn/query.ex
@@ -56,6 +56,15 @@ defmodule Plug.Conn.Query do
       iex> encode(%{foo: %{bar: "baz"}})
       "foo[bar]=baz"
 
+  It is not possible to encode maps inside lists, if the maps have 0 or more than 1 element.
+  In this case it is possible to encode the parameters using maps instead of lists:
+
+      iex> encode(%{"list" => [%{"a" => 1, "b" => 2}]})
+      ** (ArgumentError) cannot encode maps inside lists when the map has 0 or more than 1 element, got: %{\"a\" => 1, \"b\" => 2}
+
+      iex> encode(%{"list" => %{0 => %{"a" => 1, "b" => 2}}})
+      "list[0][a]=1&list[0][b]=2"
+
   For stateful decoding, see `decode_init/0`, `decode_each/2`, and `decode_done/2`.
   """
 


### PR DESCRIPTION
I had been stuck on encoding list of maps (of different size than 1), and I found https://github.com/elixir-plug/plug/issues/428#issuecomment-235673751 very useful. So I thought about adding it to the documentation.

Hopefully this can be helpful to somebody else in the future 😅 