### PR TITLE
Add `Plug.Conn.register_before_chunk/2`

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1810,7 +1810,7 @@ defmodule Plug.Conn do
     update_in(conn.private[:before_send], &[callback | &1 || []])
   end
 
- @doc ~S"""
+  @doc ~S"""
   Registers a callback to be invoked before a chunk is sent by `chunk/2`.
 
   Callbacks are invoked in the reverse order they are registered, that is, callbacks which

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -410,13 +410,18 @@ defmodule Plug.ConnTest do
     _conn =
       conn(:get, "/foo")
       |> register_before_chunk(fn conn, chunk ->
-        send(pid, {:before_chunk, chunk})
+        send(pid, {:before_chunk, 1, chunk})
+        conn
+       end)
+      |> register_before_chunk(fn conn, chunk ->
+        send(pid, {:before_chunk, 2, chunk})
         conn
        end)
       |> send_chunked(200)
       |> chunk("CHUNK")
 
-    assert_received {:before_chunk, "CHUNK"}
+    assert_received {:before_chunk, 2, "CHUNK"}
+    assert_received {:before_chunk, 1, "CHUNK"}
   end
 
   test "inform/3 performs an informational request" do

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -1428,6 +1428,14 @@ defmodule Plug.ConnTest do
     end
   end
 
+  test "register_before_chunk/2 raises when a response has already been sent" do
+    conn = send_resp(conn(:get, "/"), 200, "ok")
+
+    assert_raise Plug.Conn.AlreadySentError, fn ->
+      register_before_chunk(conn, fn _ -> nil end)
+    end
+  end
+
   test "does not delegate to connections' adapter's chunk/2 when called with an empty chunk" do
     defmodule RaisesOnEmptyChunkAdapter do
       defdelegate send_chunked(state, status, headers), to: Plug.Adapters.Test.Conn

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -409,16 +409,16 @@ defmodule Plug.ConnTest do
     pid = self()
 
     conn(:get, "/foo")
-      |> register_before_chunk(fn conn, chunk ->
-        send(pid, {:before_chunk, 1, chunk})
-        conn
-       end)
-      |> register_before_chunk(fn conn, chunk ->
-        send(pid, {:before_chunk, 2, chunk})
-        conn
-       end)
-      |> send_chunked(200)
-      |> chunk("CHUNK")
+    |> register_before_chunk(fn conn, chunk ->
+      send(pid, {:before_chunk, 1, chunk})
+      conn
+    end)
+    |> register_before_chunk(fn conn, chunk ->
+      send(pid, {:before_chunk, 2, chunk})
+      conn
+    end)
+    |> send_chunked(200)
+    |> chunk("CHUNK")
 
     assert_received {:before_chunk, 2, "CHUNK"}
     assert_received {:before_chunk, 1, "CHUNK"}
@@ -426,6 +426,7 @@ defmodule Plug.ConnTest do
 
   test "chunk/2 uses the updated conn from before_chunk callbacks" do
     pid = self()
+
     conn =
       conn(:get, "/foo")
       |> register_before_chunk(fn conn, _chunk ->
@@ -434,6 +435,7 @@ defmodule Plug.ConnTest do
         conn
       end)
       |> send_chunked(200)
+
     {:ok, conn} = chunk(conn, "CHUNK")
     {:ok, conn} = chunk(conn, "CHUNK")
     {:ok, _} = chunk(conn, "CHUNK")


### PR DESCRIPTION
Resolves #1153 

An example use case where we cache the response body for a regular HTTP request and individual chunks for a chunked response like SSEs:

```elixir
              # register lifecycle callback to cache response
              conn
              |> register_before_send(fn conn ->
                if conn.resp_body do
                  Dreamcatcher.SemanticCache.API.put(key, conn.resp_body)
                end

                conn
              end)
              |> register_before_chunk(fn conn, chunk ->
                if chunk do
                  Dreamcatcher.SemanticCache.API.append_chunk(key, chunk)
                end

                conn
              end)
```