### PR TITLE
Make whitespace (more) optional in list strings

### DIFF
--- a/lib/plug/conn/utils.ex
+++ b/lib/plug/conn/utils.ex
@@ -265,6 +265,9 @@ defmodule Plug.Conn.Utils do
       iex> list("empties, , are,, filtered")
       ["empties", "are", "filtered"]
 
+      iex> list("whitespace , , ,,   is   ,definitely,optional")
+      ["whitespace", "is", "definitely", "optional"]
+
   """
   @spec list(binary) :: [binary]
   def list(binary) do
@@ -300,7 +303,17 @@ defmodule Plug.Conn.Utils do
 
   defp strip_spaces("\r\n" <> t), do: strip_spaces(t)
   defp strip_spaces(<<h, t::binary>>) when h in [?\s, ?\t], do: strip_spaces(t)
-  defp strip_spaces(t), do: t
+  defp strip_spaces(t), do: trim_trailing(t)
+
+  defp trim_trailing(binary), do: trim_trailing(binary, byte_size(binary))
+
+  defp trim_trailing(binary, pos) do
+    if pos > 0 and :binary.at(binary, pos - 1) in [?\s, ?\t] do
+      trim_trailing(binary, pos - 1)
+    else
+      binary_part(binary, 0, pos)
+    end
+  end
 
   defp downcase_char(char) when char in @upper, do: char + 32
   defp downcase_char(char), do: char


### PR DESCRIPTION
Currently`Plug.Conn.Utils.list/1` would not handle all the whitespace around the commas if the space is before the comma.

According to what I understand from [**`RFC9110§5.6.1`**](https://www.rfc-editor.org/rfc/rfc9110#section-5.6.1), lists  should look like:

```
element *( OWS "," OWS element )
```

With OWS (Optional White Space) on either side of the commas.

Some excerpts from [**`RFC9110§5.6.3`**](https://www.rfc-editor.org/rfc/rfc9110#section-5.6.3)
- The OWS rule is used where zero or more linear whitespace octets might appear. For protocol elements where optional whitespace is preferred to improve readability, a sender SHOULD generate the optional whitespace **as a single SP**; otherwise, a sender SHOULD NOT generate optional whitespace except as needed to overwrite invalid or unwanted protocol elements during in-place message filtering.
- **OWS and RWS have the same semantics as a single SP**. Any content known to be defined as OWS or RWS MAY be replaced with a single SP before interpreting it or forwarding the message downstream.

So, right now I have it as handling only a single whitespace on either side, but we might have to clean up the string and _then_ split, or clean it up after?

### Examples

It should look like this:
```elixir
iex> Plug.Conn.Utils.list("whitespace , is,optional")
["whitespace", "is", "optional"]
```

But it looks like this:

```elixir
iex> Plug.Conn.Utils.list("whitespace , is,optional")
["whitespace ", "is", "optional"]
```

### Discuss

- Do we want this behaviour?
- Do we handle more than one space on each side of the comma?
- What is the most performant way to handle it either way?