### PR TITLE
Add Plug.Test.sent_chunks/2

### DIFF
--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -90,8 +90,10 @@ defmodule Plug.Adapters.Test.Conn do
 
   def chunk(%{method: "HEAD"} = state, _body), do: {:ok, "", state}
 
-  def chunk(%{chunks: chunks} = state, body) do
-    body = chunks <> IO.iodata_to_binary(body)
+  def chunk(%{owner: owner, ref: ref, chunks: chunks} = state, chunk) do
+    chunk = IO.iodata_to_binary(chunk)
+    send(owner, {ref, :chunk, chunk})
+    body = chunks <> chunk
     {:ok, body, %{state | chunks: body}}
   end
 

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -124,6 +124,14 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert Plug.Test.sent_chunks(conn) == ["foo", "bar"]
   end
 
+  test "sent chunks on send_resp" do
+    conn = conn(:get, "/")
+    conn = Plug.Conn.send_resp(conn, 200, "foobar")
+
+    assert conn.resp_body == "foobar"
+    assert Plug.Test.sent_chunks(conn) == []
+  end
+
   test "inform adds to the informational responses to the list" do
     conn =
       conn(:get, "/")

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -114,6 +114,16 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert child_conn.host == "www.elixir-lang.org"
   end
 
+  test "sent chunks" do
+    conn = conn(:get, "/")
+    conn = Plug.Conn.send_chunked(conn, 200)
+    {:ok, conn} = Plug.Conn.chunk(conn, "foo")
+    {:ok, conn} = Plug.Conn.chunk(conn, "bar")
+
+    assert conn.resp_body == "foobar"
+    assert Plug.Test.sent_chunks(conn) == ["foo", "bar"]
+  end
+
   test "inform adds to the informational responses to the list" do
     conn =
       conn(:get, "/")


### PR DESCRIPTION
Before this patch there was no way to reconstruct the invidual chunks that were sent. All we got was the full resulting body in `conn.resp_body`.

For completeness, I believe instead of messaging we could store chunks in a list in the test adapter state and simply append:

```diff
- def send_chunked(state, _status, _headers), do: {:ok, "", %{state | chunks: ""}}
+ def send_chunked(state, _status, _headers), do: {:ok, "", %{state | chunks: []}}

- def chunk(%{owner: owner, ref: ref, chunks: chunks} = state, chunk) do
-   send(owner, {ref, :chunk, chunk})
-   body = chunks <> IO.iodata_to_binary(chunk)
-   {:ok, body, %{state | chunks: body}}
- end
+ def chunk(%{owner: owner, ref: ref, chunks: chunks} = state, chunk) do
+   chunk = IO.iodata_to_binary(chunk)
+   body = IO.iodata_to_binary([chunks, chunk])
+   {:ok, body, %{state | chunks: chunks ++ [chunk]}}
+ end
```

but I was following the existing functions `sent_informs` and `sent_upgrades`.

My use case is to be able to test response streaming using Req :plug adapter:

```elixir
req =
  Req.new(
    plug: fn conn ->
      conn = Plug.Conn.send_chunked(conn, 200)
      {:ok, conn} = Plug.Conn.chunk(conn, "foo")
      {:ok, conn} = Plug.Conn.chunk(conn, "bar")
      conn
    end,
    into: []
  )

resp = Req.request!(req)
assert resp.body == ["foo", "bar"]
```