### PR TITLE
Adds except option to plug parsers

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -105,6 +105,9 @@ defmodule Plug.Parsers do
       `Plug.Parsers.MULTIPART` which relies instead on other functions defined
       in `Plug.Conn`.
 
+    * `:except` - an optional path or list of path roots that will be ignored
+      by the parser.
+
   All other options given to this Plug are forwarded to the parsers.
 
   ## Examples

--- a/test/plug/parsers_test.exs
+++ b/test/plug/parsers_test.exs
@@ -448,4 +448,24 @@ defmodule Plug.ParsersTest do
     assert conn.params["foo"] == "bar"
     assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
   end
+
+  test "does not fetch when conn path matches except root" do
+    conn =
+      conn(:post, "/except", "foo=baz")
+      |> put_req_header("content-type", "application/x-www-form-urlencoded")
+      |> parse(except: "/except")
+
+    assert conn.params == %Plug.Conn.Unfetched{aspect: :params}
+    assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+  end
+
+  test "does not fetch when conn path matches except root, one of a list" do
+    conn =
+      conn(:post, "/also-except", "foo=baz")
+      |> put_req_header("content-type", "application/x-www-form-urlencoded")
+      |> parse(except: ["/except", "/also-except"])
+
+    assert conn.params == %Plug.Conn.Unfetched{aspect: :params}
+    assert conn.body_params == %Plug.Conn.Unfetched{aspect: :body_params}
+  end
 end


### PR DESCRIPTION
this PR adds an `except` option to Plug.Parsers that lets you selectively ignore path prefixes for the particular parser, useful if you have a plug that will do special-cased parsing.