### PR TITLE
Add `assign_as` option for Plug.RequestId

### DIFF
--- a/test/plug/request_id_test.exs
+++ b/test/plug/request_id_test.exs
@@ -65,6 +65,22 @@ defmodule Plug.RequestIdTest do
     assert res_request_id == meta_request_id
   end
 
+  test "assigns the request id to conn.assigns when given an assignment key" do
+    request_id = "existingidthatislongenough"
+
+    conn =
+      conn(:get, "/")
+      |> put_req_header("x-request-id", request_id)
+      |> call(assign_as: :plug_request_id)
+
+    [res_request_id] = get_resp_header(conn, "x-request-id")
+    meta_request_id = Logger.metadata()[:request_id]
+    assigned_request_id = conn.assigns.plug_request_id
+    assert assigned_request_id == request_id
+    assert res_request_id == assigned_request_id
+    assert res_request_id == meta_request_id
+  end
+
   defp generated_request_id?(request_id) do
     Regex.match?(~r/\A[A-Za-z0-9-_]+\z/, request_id)
   end


### PR DESCRIPTION
- `:assign_as` - The name of the key that will be used to store the
  discovered or generated request id in `conn.private`. If not provided,
  the request id will not be stored.

  ```elixir
  plug Plug.RequestId, assign_as: :plug_request_id
  ```

Resolves: #1171
