### PR TITLE
Update reason phrase for HTTP 422 to match current standard

### DIFF
--- a/lib/plug/conn/status.ex
+++ b/lib/plug/conn/status.ex
@@ -49,7 +49,7 @@ defmodule Plug.Conn.Status do
     417 => "Expectation Failed",
     418 => "I'm a teapot",
     421 => "Misdirected Request",
-    422 => "Unprocessable Entity",
+    422 => "Unprocessable Content",
     423 => "Locked",
     424 => "Failed Dependency",
     425 => "Too Early",


### PR DESCRIPTION
While working on a Phoenix project, I noticed that the atom `:unprocessable_entity` representing `422`, doesn't match the reason phrase I've seen elsewhere.

Turns out that HTTP status code `422` (with the reason phrase "Unprocessable *Entity*") was initially proposed for WebDAV (in [RFC 2518](https://www.rfc-editor.org/rfc/rfc2518#section-10.3) and [RFC 4918](https://www.rfc-editor.org/rfc/rfc4918.html#section-11.2)).

[RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html) (the HTTP Semantics standard) was published in June 2022. `422` is defined in section [15.5.21](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.21) with reason phrase "Unprocessable *Content*".

That is also how it is currently defined in the [IANA HTTP Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).

MDN also lists the newer phrase: [422 Unprocessable Content | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422). So it would be great to get plug up to date with the current standard 😊

But since this will change the atom it would be a breaking change - I'll let the maintainers comment on how they wish to handle this. 

PS. I also noticed a couple of other codes that seemed misaligned with the IANA registry, let me know if I should create updates to those as well 😇 