### PR TITLE
Allow to specify a port from the conn

### DIFF
--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -36,6 +36,8 @@ defmodule Plug.Adapters.Test.Conn do
         })
     }
 
+    conn_port = if conn.port != 0, do: conn.port, else: 80
+
     %Plug.Conn{
       conn
       | adapter: {__MODULE__, state},
@@ -43,7 +45,7 @@ defmodule Plug.Adapters.Test.Conn do
         method: method,
         owner: owner,
         path_info: split_path(uri.path),
-        port: uri.port || 80,
+        port: uri.port || conn_port,
         remote_ip: conn.remote_ip || {127, 0, 0, 1},
         req_headers: req_headers,
         request_path: uri.path,

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -152,6 +152,12 @@ defmodule Plug.Adapters.Test.ConnTest do
     assert child_conn.remote_ip == {151, 236, 219, 228}
   end
 
+  test "use existing conn.port if exists" do
+    conn_with_port = %Plug.Conn{conn(:get, "/") | port: 4200}
+    child_conn = Plug.Adapters.Test.Conn.conn(conn_with_port, :get, "/", foo: "bar")
+    assert child_conn.port == 4200
+  end
+
   test "use custom peer data" do
     peer_data = %{address: {127, 0, 0, 1}, port: 111_317}
     conn = conn(:get, "/") |> put_peer_data(peer_data)


### PR DESCRIPTION
Hey there 👋🏾 

Currently the port can be specified by an URI like http://localhost:4200 but in phoenix it's required to do a:

```elixir
get(conn, "http://localhost:42000/my/path", ...)
```

Because we do an `URI.parse/1` here https://github.com/elixir-plug/plug/blob/main/lib/plug/adapters/test/conn.ex#L9

Instead the `port` in the `conn` struct could be change and that should be cleaner rather than specifing a full URI, in phoenix tests.

Thanks for creating Plug!!

PS: Hope that this PR makes sense 😉 