### PR TITLE
Question: Allow unsetting headers in merge_*_headers?

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -718,8 +718,8 @@ defmodule Plug.Conn do
   As a convenience, when using the `Plug.Adapters.Conn.Test` adapter, any
   headers that aren't lowercase will raise a `Plug.Conn.InvalidHeaderError`.
 
-  Including a header with value `false` or `nil` will remove the first
-  occurrence of that header.
+  Including a header with value `nil` will remove the first occurrence of
+  that header.
 
   ## Example
 
@@ -740,7 +740,7 @@ defmodule Plug.Conn do
   def merge_req_headers(%Conn{req_headers: current, adapter: adapter} = conn, headers) do
     headers =
       Enum.reduce(headers, current, fn
-        {key, value}, acc when is_binary(key) and value in [false, nil] ->
+        {key, value}, acc when is_binary(key) and is_nil(value) ->
           validate_req_header!(adapter, key)
           List.keydelete(acc, key, 0)
 
@@ -947,8 +947,8 @@ defmodule Plug.Conn do
   As a convenience, when using the `Plug.Adapters.Conn.Test` adapter, any
   headers that aren't lowercase will raise a `Plug.Conn.InvalidHeaderError`.
 
-  Including a header with value `false` or `nil` will remove the first
-  occurrence of that header.
+  Including a header with value `nil` will remove the first occurrence of
+  that header.
 
   ## Example
 
@@ -969,7 +969,7 @@ defmodule Plug.Conn do
   def merge_resp_headers(%Conn{resp_headers: current, adapter: adapter} = conn, headers) do
     headers =
       Enum.reduce(headers, current, fn
-        {key, value}, acc when is_binary(key) and value in [false, nil] ->
+        {key, value}, acc when is_binary(key) and is_nil(value) ->
           validate_header_key_normalized_if_test!(adapter, key)
           validate_header_key!(key)
           List.keydelete(acc, key, 0)

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -652,10 +652,8 @@ defmodule Plug.ConnTest do
     assert get_resp_header(conn2, "x-foo") == ["new"]
     assert get_resp_header(conn2, "x-bar") == ["baz"]
     assert length(conn1.resp_headers) == length(conn2.resp_headers)
-    conn3 = merge_resp_headers(conn2, %{"x-bar" => false})
+    conn3 = merge_resp_headers(conn2, %{"x-bar" => nil})
     assert get_resp_header(conn3, "x-bar") == []
-    conn4 = merge_resp_headers(conn3, %{"x-foo" => nil})
-    assert get_resp_header(conn4, "x-foo") == []
   end
 
   test "delete_resp_header/2" do
@@ -749,10 +747,8 @@ defmodule Plug.ConnTest do
     assert get_req_header(conn2, "x-foo") == ["new"]
     assert get_req_header(conn2, "x-bar") == ["baz"]
     assert length(conn1.req_headers) == length(conn2.req_headers)
-    conn3 = merge_req_headers(conn2, %{"x-bar" => false})
+    conn3 = merge_req_headers(conn2, %{"x-bar" => nil})
     assert get_resp_header(conn3, "x-bar") == []
-    conn4 = merge_req_headers(conn3, %{"x-foo" => nil})
-    assert get_resp_header(conn4, "x-foo") == []
   end
 
   test "prepend_req_headers/2" do

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -652,6 +652,10 @@ defmodule Plug.ConnTest do
     assert get_resp_header(conn2, "x-foo") == ["new"]
     assert get_resp_header(conn2, "x-bar") == ["baz"]
     assert length(conn1.resp_headers) == length(conn2.resp_headers)
+    conn3 = merge_resp_headers(conn2, %{"x-bar" => false})
+    assert get_resp_header(conn3, "x-bar") == []
+    conn4 = merge_resp_headers(conn3, %{"x-foo" => nil})
+    assert get_resp_header(conn4, "x-foo") == []
   end
 
   test "delete_resp_header/2" do
@@ -745,6 +749,10 @@ defmodule Plug.ConnTest do
     assert get_req_header(conn2, "x-foo") == ["new"]
     assert get_req_header(conn2, "x-bar") == ["baz"]
     assert length(conn1.req_headers) == length(conn2.req_headers)
+    conn3 = merge_req_headers(conn2, %{"x-bar" => false})
+    assert get_resp_header(conn3, "x-bar") == []
+    conn4 = merge_req_headers(conn3, %{"x-foo" => nil})
+    assert get_resp_header(conn4, "x-foo") == []
   end
 
   test "prepend_req_headers/2" do


### PR DESCRIPTION
Hi there 👋🏼 

This PR is primarily for discussion; code is just for demonstration.

Would you be interested in allowing folks to remove / unset headers in `Plug.Conn.merge_req_headers/2` and `Plug.Conn.merge_resp_headers/2`? This would potentially allow more succinct management of headers (as opposed to calling the corresponding `delete_` functions multiple times).

For context: some headers, like `X-Frame-Options`, have semantics based on their existence in addition to their value. This means that certain behaviours require removing the header completely if it was previously set. That's possible today with `delete_resp_header`, but a merge call can be more expressive in certain contexts.

Cheers ❤️ 