### PR TITLE
Support returning {:ok, payload} from adapter.inform/3

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1339,6 +1339,9 @@ defmodule Plug.Conn do
       :ok ->
         conn
 
+      {:ok, payload} ->
+        put_in(conn.adapter, {adapter, payload}
+      
       {:error, :not_supported} ->
         raise "inform is not supported by #{inspect(adapter)}." <>
                 "You should either delete the call to `inform!/3` or switch to an " <>

--- a/lib/plug/conn/adapter.ex
+++ b/lib/plug/conn/adapter.ex
@@ -131,7 +131,7 @@ defmodule Plug.Conn.Adapter do
   should be returned.
   """
   @callback inform(payload, status :: Conn.status(), headers :: Keyword.t()) ::
-              :ok | {:error, term}
+              :ok | {:ok, payload()} | {:error, term()}
 
   @doc """
   Attempt to upgrade the connection with the client.

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -438,6 +438,11 @@ defmodule Plug.ConnTest do
     )
   end
 
+  test "inform!/3 performs an informational request" do
+    conn = conn(:get, "/foo") |> inform!(103, [{"link", "</style.css>; rel=preload; as=style"}])
+    assert {103, [{"link", "</style.css>; rel=preload; as=style"}]} in sent_informs(conn)
+  end
+
   test "upgrade_adapter/3 requests an upgrade" do
     conn = conn(:get, "/foo") |> upgrade_adapter(:supported, opt: :supported)
     assert {:supported, [opt: :supported]} in sent_upgrades(conn)


### PR DESCRIPTION
There is a minor Bandit [bug](https://github.com/mtrudel/bandit/pull/268) where it looks like it does _not_ support inform but it definitely does. Turns out using Plug.Conn.inform/3 worked but inform!/3 did not. The bug in Bandit was wrong return value which went unchecked in inform/3 but got incorrectly interpreted in inform!/3.

This is not a breaking change for inform!/3 as we were already raising but it could be considered a breaking change for inform/3 but in this particular case it seemed warranted to me.

cc @mtrudel 