### PR TITLE
Add parameter for function on how to handle invalid strings when validating for UTF-8 #1159

### DIFF
--- a/lib/plug/parsers/multipart.ex
+++ b/lib/plug/parsers/multipart.ex
@@ -185,7 +185,8 @@ defmodule Plug.Parsers.MULTIPART do
           parse_multipart_body(Plug.Conn.read_part_body(conn, opts), limit, opts, "")
 
         if Keyword.get(opts, :validate_utf8, true) do
-          Plug.Conn.Utils.validate_utf8!(body, Plug.Parsers.BadEncodingError, "multipart body")
+          on_err_func = Keyword.get(opts, :on_err_func, fn reason -> raise Plug.Parsers.BadEncodingError, reason end)
+          Plug.Conn.Utils.validate_utf8(body, on_err_func, "multipart body")
         end
 
         {conn, limit, [{name, headers, body} | acc]}

--- a/lib/plug/parsers/urlencoded.ex
+++ b/lib/plug/parsers/urlencoded.ex
@@ -31,13 +31,15 @@ defmodule Plug.Parsers.URLENCODED do
     case apply(mod, fun, [conn, opts | args]) do
       {:ok, body, conn} ->
         validate_utf8 = Keyword.get(opts, :validate_utf8, true)
+        on_err_func = Keyword.get(opts, :on_err_func, fn reason -> raise Plug.Parsers.BadEncodingError, reason end)
 
         {:ok,
          Plug.Conn.Query.decode(
            body,
            %{},
            Plug.Parsers.BadEncodingError,
-           validate_utf8
+           validate_utf8,
+           on_err_func
          ), conn}
 
       {:more, _data, conn} ->

--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -62,8 +62,8 @@ defmodule Plug.Test do
 
   """
   @spec conn(String.Chars.t(), binary, params) :: Conn.t()
-  def conn(method, path, params_or_body \\ nil) do
-    Plug.Adapters.Test.Conn.conn(%Plug.Conn{}, method, path, params_or_body)
+  def conn(method, path, params_or_body \\ nil, decode_func \\ fn query -> Plug.Conn.Query.decode(query) end) do
+    Plug.Adapters.Test.Conn.conn(%Plug.Conn{}, method, path, params_or_body, decode_func)
   end
 
   @doc """


### PR DESCRIPTION
[#1159](https://github.com/elixir-plug/plug/issues/1159) asked for the possibility for more custom behavior when failing validations of UTF-8 strings. This PR adds a new function Plug.Conn.Utils.validate_utf8/3 as an alternative to Plug.Conn.Utils.validate_utf8!/3. The new function has a parameter for a function on how to handle a failure (with the error message supplied as input to the function).
The changes are backward compatible, but updating Plug.Conn.Query to use the new function makes the signature of Plug.Conn.Query.decode/5 a bit verbose and clunky. When the try-rescue will be removed from Plug.Conn.Query.decode_www_pair/4, there will no longer be any need for both a parameter for an exception and a function, but it would be a breaking change in the future to remove the exception parameter in favor of only the function.