### PR TITLE
Add underscore support for MIME types

### DIFF
--- a/lib/plug/conn/utils.ex
+++ b/lib/plug/conn/utils.ex
@@ -8,7 +8,7 @@ defmodule Plug.Conn.Utils do
   @upper ?A..?Z
   @lower ?a..?z
   @alpha ?0..?9
-  @other [?., ?-, ?+]
+  @other [?., ?-, ?+, ?_]
   @space [?\s, ?\t]
   @specials ~c|()<>@,;:\\"/[]?={}|
 
@@ -31,6 +31,9 @@ defmodule Plug.Conn.Utils do
 
       iex> media_type "APPLICATION/vnd.ms-data+XML"
       {:ok, "application", "vnd.ms-data+xml", %{}}
+
+      iex> media_type "application/media_control+xml"
+      {:ok, "application", "media_control+xml", %{}}
 
       iex> media_type "text/*; q=1.0"
       {:ok, "text", "*", %{"q" => "1.0"}}


### PR DESCRIPTION
This PR introduces support for underscore characters in MIME types, addressing an issue where valid MIME types containing underscores were incorrectly returning errors.

With this fix, MIME types that include underscore characters are correctly parsed and do not return an error. The behavior is now consistent with the [IANA list of MIME types](https://www.iana.org/assignments/media-types/media-types.xhtml), which includes some types with underscores.

### Current behaviour

```
Plug.Conn.Utils.media_type("application/media_control+xml")
:error
```

### After the fix
```
Plug.Conn.Utils.media_type("application/media_control+xml")
{:ok, "application", "media_control+xml", %{}}
```

