### PR TITLE
Add support for Partitioned cookie attribute

### DIFF
--- a/lib/plug/conn/cookies.ex
+++ b/lib/plug/conn/cookies.ex
@@ -62,6 +62,7 @@ defmodule Plug.Conn.Cookies do
       emit_if(Map.get(opts, :secure, false), "; secure"),
       emit_if(Map.get(opts, :http_only, true), "; HttpOnly"),
       emit_if(Map.get(opts, :same_site, nil), &encode_same_site/1),
+      emit_if(Map.get(opts, :partitioned, false), "; Partitioned"),
       emit_if(opts[:extra], &["; ", &1])
     ])
   end

--- a/test/plug/conn/cookies_test.exs
+++ b/test/plug/conn/cookies_test.exs
@@ -86,6 +86,10 @@ defmodule Plug.Conn.CookiesTest do
     assert encode("foo", %{value: "bar", http_only: false}) == "foo=bar; path=/"
   end
 
+  test "encodes with :partitioned option" do
+    assert encode("foo", %{value: "bar", partitioned: true}) == "foo=bar; path=/; HttpOnly; Partitioned"
+  end
+
   test "encodes with :max_age" do
     start = {{2012, 9, 29}, {15, 32, 10}}
 


### PR DESCRIPTION
Add support for `Partitioned` cookie attribute

This attribute is used for partitioned cookies, aka Cookies Having
Independent Partitioned State (CHIPS).

This is a new feature being developed by Chrome/Chromium which was
enabled by default starting in version 114 (current latest version is
126).

The goal of this feature is to allow third party cookies without
allowing these third parties to track users across domains.

https://developers.google.com/privacy-sandbox/3pcd/chips
https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies

Do the Plug maintainers think this feature is stable/supported enough for adoption by Plug?