### PR TITLE
Add Plug.Conn.Utils tests

### DIFF
--- a/lib/plug/conn/utils.ex
+++ b/lib/plug/conn/utils.ex
@@ -117,6 +117,9 @@ defmodule Plug.Conn.Utils do
       iex> content_type "*/*"
       :error
 
+      iex> content_type "something"
+      :error
+
   """
   @spec content_type(binary) :: {:ok, type :: binary, subtype :: binary, params} | :error
   def content_type(binary) do
@@ -160,6 +163,9 @@ defmodule Plug.Conn.Utils do
       %{}
 
       iex> params(";")
+      %{}
+
+      iex> params("foo=")
       %{}
 
   """


### PR DESCRIPTION
* Add test for when Plug.Conn.Utils.content_type/1 is given a binary that is an erroneous content type.

* Add test for when Plug.Conn.Utils.params/1 is given a binary containing a parameter key but no value.