### PR TITLE
Add Plug.Conn.Cookies tests

### DIFF
--- a/test/plug/conn/cookies_test.exs
+++ b/test/plug/conn/cookies_test.exs
@@ -17,6 +17,7 @@ defmodule Plug.Conn.CookiesTest do
     assert decode("  key1=value1 , key2=value2  ") == %{"key1" => "value1 , key2=value2"}
     assert decode("") == %{}
     assert decode("=") == %{}
+    assert decode("=;") == %{}
     assert decode("key, =, value") == %{}
     assert decode("key=") == %{"key" => ""}
     assert decode("key1=;;key2=") == %{"key1" => "", "key2" => ""}
@@ -48,6 +49,7 @@ defmodule Plug.Conn.CookiesTest do
   test "encodes the cookie" do
     assert encode("foo", %{value: "bar"}) == "foo=bar; path=/; HttpOnly"
     assert encode("foo", %{}) == "foo=; path=/; HttpOnly"
+    assert encode("foo") == "foo=; path=/; HttpOnly"
   end
 
   test "encodes with :path option" do
@@ -87,10 +89,89 @@ defmodule Plug.Conn.CookiesTest do
   end
 
   test "encodes with :max_age" do
-    start = {{2012, 9, 29}, {15, 32, 10}}
+    assert encode("foo", %{
+             value: "bar",
+             max_age: 60,
+             universal_time: {{2012, 1, 7}, {15, 32, 10}}
+           }) ==
+             "foo=bar; path=/; expires=Sat, 07 Jan 2012 15:33:10 GMT; max-age=60; HttpOnly"
 
-    assert encode("foo", %{value: "bar", max_age: 60, universal_time: start}) ==
-             "foo=bar; path=/; expires=Sat, 29 Sep 2012 15:33:10 GMT; max-age=60; HttpOnly"
+    assert encode("foo", %{
+             value: "bar",
+             max_age: 60,
+             universal_time: {{2012, 2, 7}, {15, 32, 10}}
+           }) ==
+             "foo=bar; path=/; expires=Tue, 07 Feb 2012 15:33:10 GMT; max-age=60; HttpOnly"
+
+    assert encode("foo", %{
+             value: "bar",
+             max_age: 60,
+             universal_time: {{2012, 3, 7}, {15, 32, 10}}
+           }) ==
+             "foo=bar; path=/; expires=Wed, 07 Mar 2012 15:33:10 GMT; max-age=60; HttpOnly"
+
+    assert encode("foo", %{
+             value: "bar",
+             max_age: 60,
+             universal_time: {{2012, 4, 7}, {15, 32, 10}}
+           }) ==
+             "foo=bar; path=/; expires=Sat, 07 Apr 2012 15:33:10 GMT; max-age=60; HttpOnly"
+
+    assert encode("foo", %{
+             value: "bar",
+             max_age: 60,
+             universal_time: {{2012, 5, 7}, {15, 32, 10}}
+           }) ==
+             "foo=bar; path=/; expires=Mon, 07 May 2012 15:33:10 GMT; max-age=60; HttpOnly"
+
+    assert encode("foo", %{
+             value: "bar",
+             max_age: 60,
+             universal_time: {{2012, 6, 7}, {15, 32, 10}}
+           }) ==
+             "foo=bar; path=/; expires=Thu, 07 Jun 2012 15:33:10 GMT; max-age=60; HttpOnly"
+
+    assert encode("foo", %{
+             value: "bar",
+             max_age: 60,
+             universal_time: {{2012, 7, 7}, {15, 32, 10}}
+           }) ==
+             "foo=bar; path=/; expires=Sat, 07 Jul 2012 15:33:10 GMT; max-age=60; HttpOnly"
+
+    assert encode("foo", %{
+             value: "bar",
+             max_age: 60,
+             universal_time: {{2012, 8, 7}, {15, 32, 10}}
+           }) ==
+             "foo=bar; path=/; expires=Tue, 07 Aug 2012 15:33:10 GMT; max-age=60; HttpOnly"
+
+    assert encode("foo", %{
+             value: "bar",
+             max_age: 60,
+             universal_time: {{2012, 9, 7}, {15, 32, 10}}
+           }) ==
+             "foo=bar; path=/; expires=Fri, 07 Sep 2012 15:33:10 GMT; max-age=60; HttpOnly"
+
+    assert encode("foo", %{
+             value: "bar",
+             max_age: 60,
+             universal_time: {{2012, 10, 7}, {15, 32, 10}}
+           }) ==
+             "foo=bar; path=/; expires=Sun, 07 Oct 2012 15:33:10 GMT; max-age=60; HttpOnly"
+
+    assert encode("foo", %{
+             value: "bar",
+             max_age: 60,
+             universal_time: {{2012, 11, 7}, {15, 32, 10}}
+           }) ==
+             "foo=bar; path=/; expires=Wed, 07 Nov 2012 15:33:10 GMT; max-age=60; HttpOnly"
+
+    assert encode("foo", %{
+             value: "bar",
+             max_age: 60,
+             universal_time: {{2012, 12, 7}, {15, 32, 10}}
+           }) ==
+             "foo=bar; path=/; expires=Fri, 07 Dec 2012 15:33:10 GMT; max-age=60; HttpOnly"
   end
 
   test "encodes with :extra option" do


### PR DESCRIPTION
* Add test for when Plug.Conn.Cookies.decode/1 is given an argument equal to "=;".

* Add test for Plug.Conn.Cookies.encode/2 that uses only the first argument, so that the default value of the second argument is used.

* Expand the "encodes with :max_age" test to include test cases for all of the weekday and month names, and padding of a number (day) between 0 and 9.