### PR TITLE
Add Plug.BasicAuth test

### DIFF
--- a/test/plug/basic_auth_test.exs
+++ b/test/plug/basic_auth_test.exs
@@ -15,6 +15,14 @@ defmodule Plug.BasicAuthTest do
       refute conn.halted
     end
 
+    test "raises key error when no options are given" do
+      assert_raise KeyError, fn ->
+        conn(:get, "/")
+        |> put_req_header("authorization", encode_basic_auth("hello", "world"))
+        |> basic_auth()
+      end
+    end
+
     test "refutes invalid user and password" do
       for {user, pass} <- [{"hello", "wrong"}, {"wrong", "hello"}] do
         conn =


### PR DESCRIPTION
* Add test that asserts Plug.BasicAuth.basic_auth/2 raises key error when no options are given and default options are used.