### PR TITLE
Plug Debugger add ability to wrap exception text

### DIFF
--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -580,10 +580,6 @@
         margin: 0;
     }
 
-    .code-quote > li {
-        padding: 6px 0;
-    }
-
     .code.-padded {
         padding: 0 16px 16px 16px;
     }

--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -146,7 +146,13 @@
 
     .exception-info > code {
         line-height: 1.5;
+        font-size: <%= :math.pow(1.3, -1) %>em;
     }
+
+    .wrap-text-checkbox-container {
+        display: flex;
+        gap: 6px;
+     }
 
     /*
      * Code explorer
@@ -574,6 +580,10 @@
         margin: 0;
     }
 
+    .code-quote > li {
+        padding: 6px 0;
+    }
+
     .code.-padded {
         padding: 0 16px 16px 16px;
     }
@@ -676,7 +686,10 @@
                 <small>at <%= h method(@conn) %></small>
                 <small class="path"><%= h @conn.request_path %></small>
             </h5>
-            <code><pre><%= h @message %></pre></code>
+            <code><pre role="exception-details-text"><%= h @message %></pre></code>
+            <div class="wrap-text-checkbox-container">
+                <input role="wrap-text-checkbox" type="checkbox" value="wrap_text">Wrap text?
+            </div>
         </header>
 
         <%= for %{label: label, encoded_handler: encoded_handler} <- @actions do %>
@@ -836,6 +849,8 @@
         var $copyBtn = document.querySelector('[role~="copy-to-markdown"]')
         var $copyBtnText = document.querySelector('[role~="copy-to-markdown-text"]')
         var $copy = document.querySelector('[role~="copy-contents"]')
+        var $exceptionDetailsText = document.querySelector('[role~="exception-details-text"]')
+        var $wrapTextCheckbox = document.querySelector('[role~="wrap-text-checkbox"]')
 
         each($items, function ($item) {
             on($item, 'click', itemOnclick)
@@ -843,8 +858,17 @@
 
         on($toggle, 'click', toggleOnclick)
         on($copyBtn, 'click', copyToClipboard)
+        on($wrapTextCheckbox, 'click', toggleWrapExceptionText)
 
         restoreToggle()
+
+        function toggleWrapExceptionText () {
+            if ($exceptionDetailsText.style.whiteSpace === 'pre-wrap') {
+                $exceptionDetailsText.style.whiteSpace = '';
+            } else {
+                $exceptionDetailsText.style.whiteSpace = 'pre-wrap';
+            }
+        }
 
         function copyToClipboard () {
           if(navigator.clipboard) {

--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -149,9 +149,8 @@
         font-size: <%= :math.pow(1.3, -1) %>em;
     }
 
-    .wrap-text-checkbox-container {
-        display: flex;
-        gap: 6px;
+    .exception-details-text {
+        white-space: pre-wrap;
      }
 
     /*
@@ -682,10 +681,7 @@
                 <small>at <%= h method(@conn) %></small>
                 <small class="path"><%= h @conn.request_path %></small>
             </h5>
-            <code><pre role="exception-details-text"><%= h @message %></pre></code>
-            <div class="wrap-text-checkbox-container">
-                <input role="wrap-text-checkbox" type="checkbox" value="wrap_text">Wrap text?
-            </div>
+            <code><pre class="exception-details-text"><%= h @message %></pre></code>
         </header>
 
         <%= for %{label: label, encoded_handler: encoded_handler} <- @actions do %>
@@ -845,8 +841,6 @@
         var $copyBtn = document.querySelector('[role~="copy-to-markdown"]')
         var $copyBtnText = document.querySelector('[role~="copy-to-markdown-text"]')
         var $copy = document.querySelector('[role~="copy-contents"]')
-        var $exceptionDetailsText = document.querySelector('[role~="exception-details-text"]')
-        var $wrapTextCheckbox = document.querySelector('[role~="wrap-text-checkbox"]')
 
         each($items, function ($item) {
             on($item, 'click', itemOnclick)
@@ -854,17 +848,8 @@
 
         on($toggle, 'click', toggleOnclick)
         on($copyBtn, 'click', copyToClipboard)
-        on($wrapTextCheckbox, 'click', toggleWrapExceptionText)
 
         restoreToggle()
-
-        function toggleWrapExceptionText () {
-            if ($exceptionDetailsText.style.whiteSpace === 'pre-wrap') {
-                $exceptionDetailsText.style.whiteSpace = '';
-            } else {
-                $exceptionDetailsText.style.whiteSpace = 'pre-wrap';
-            }
-        }
 
         function copyToClipboard () {
           if(navigator.clipboard) {


### PR DESCRIPTION
Sometimes exceptions print out with really long lines which makes it difficult to read the exceptions on the error page:

https://github.com/user-attachments/assets/f276000c-4c6c-43a1-86bd-1355dc89c7b6

This PR wraps the text and decreases the font size so more can be read without scrolling:
![Screenshot 2024-08-26 08-26-46@2x](https://github.com/user-attachments/assets/3e7ba2cb-49fb-4242-9fa5-86f118895982)


<details><summary>previous implementation</summary>
This PR adds a "Wrap text?" checkbox that toggles wrapping on the exception details:

https://github.com/user-attachments/assets/aa18c6fc-3f25-4646-8a50-2d68c0714696

It also decreases the font size slightly so that it is easier to read the details

Alternatively we may want to only change the CSS to always wrap and also decrease the font-size. Or maybe keep the checkbox but default it to on.
</details>