### PR TITLE
Plug Debugger add spacing between arguments

### DIFF
--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -574,6 +574,10 @@
         margin: 0;
     }
 
+    .code-quote > li {
+        padding: 6px 0;
+    }
+
     .code.-padded {
         padding: 0 16px 16px 16px;
     }

--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -277,7 +277,8 @@
 
     .frame-info > details.meta > ol > li:before {
         content: counter(item) ". ";
-        color: <%= @style.accent %>;
+        color: <%= @style.primary %>;
+        filter: saturate(50%);
     }
 
     /*


### PR DESCRIPTION
Some exceptions can have arguments that are very long when printed out (I'm looking at you `%Plug.Conn{}`!):
![Screenshot 2024-08-24 08-28-08@2x](https://github.com/user-attachments/assets/20cb5a66-8e14-4c4c-a322-4e5f14eb80e9)

This makes it very difficult to at-a-glance find the second, third, etc arguments (for what it's worth, I find this true in IEx as well). This PR improves this issue by adding some spacing between the arguments so that they stand out more as well as switching the numbers to use the primary color (but with 50% filter applied so it doesn't stick out _too_ much). I like the coloring change because it makes it more clear that the numbers are not part of the exception itself.

Here's the changes:
![Screenshot 2024-08-24 08-47-21@2x](https://github.com/user-attachments/assets/66cc7b40-d613-451a-b3a5-4cb2d3ca5327)

And here's the first screenshot with the changes:

![Screenshot 2024-08-24 08-51-06@2x](https://github.com/user-attachments/assets/56eec675-67be-40e6-bcdf-298fb976435d)
