### PR TITLE
Docs: Improve custom body reader example in `Plug.Parsers` module

### DIFF
--- a/lib/plug/parsers.ex
+++ b/lib/plug/parsers.ex
@@ -192,9 +192,10 @@ defmodule Plug.Parsers do
 
       defmodule CacheBodyReader do
         def read_body(conn, opts) do
-          {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
-          conn = update_in(conn.assigns[:raw_body], &[body | (&1 || [])])
-          {:ok, body, conn}
+          with {:ok, body, conn} <- Plug.Conn.read_body(conn, opts) do
+            conn = update_in(conn.assigns[:raw_body], &[body | &1 || []])
+            {:ok, body, conn}
+          end
         end
       end
 


### PR DESCRIPTION
## Change example to use `with`

Change from:
```elixir
{:ok, body, conn} = Plug.Conn.read_body(conn, opts)
```
 To:
```elixir
with {:ok, body, conn} <- Plug.Conn.read_body(conn, opts) do
```

This ensures that if `Plug.Conn.read_body/2` fails, the function will return a meaningful error tuple instead of raising a `MatchError`. I saw this also suggested in this Dashbit [article](https://dashbit.co/blog/how-we-verify-webhooks).

## Remove extra parentheses

Change from:
```elixir
conn = update_in(conn.assigns[:raw_body], &[body | (&1 || [])])
```
To:
```elixir
conn = update_in(conn.assigns[:raw_body], &[body | &1 || []])
```

This just removes the extra parens that the Elixir formatter would remove. :)