### PR TITLE
Add SSL validation support for `certs_keys`

### DIFF
--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -169,6 +169,7 @@ defmodule Plug.SSL do
     |> check_for_missing_keys()
     |> validate_ciphers()
     |> normalize_ssl_files()
+    |> normalize_certs_keys_ssl_files()
     |> convert_to_charlist()
     |> set_secure_defaults()
     |> configure_managed_tls()
@@ -179,14 +180,15 @@ defmodule Plug.SSL do
   end
 
   defp check_for_missing_keys(options) do
+    has_certs_keys? = List.keymember?(options, :certs_keys, 0)
     has_sni? = List.keymember?(options, :sni_hosts, 0) or List.keymember?(options, :sni_fun, 0)
     has_key? = List.keymember?(options, :key, 0) or List.keymember?(options, :keyfile, 0)
     has_cert? = List.keymember?(options, :cert, 0) or List.keymember?(options, :certfile, 0)
 
     cond do
       has_sni? -> options
-      not has_key? -> fail("missing option :key/:keyfile")
-      not has_cert? -> fail("missing option :cert/:certfile")
+      not (has_key? or has_certs_keys?) -> fail("missing option :key/:keyfile/:certs_keys")
+      not (has_cert? or has_certs_keys?) -> fail("missing option :cert/:certfile/:certs_keys")
       true -> options
     end
   end
@@ -194,6 +196,22 @@ defmodule Plug.SSL do
   defp normalize_ssl_files(options) do
     ssl_files = [:keyfile, :certfile, :cacertfile, :dhfile]
     Enum.reduce(ssl_files, options, &normalize_ssl_file(&1, &2))
+  end
+
+  defp normalize_certs_keys_ssl_files(options) do
+    if certs_keys = options[:certs_keys] do
+      ssl_files = [:keyfile, :certfile]
+
+      updated_certs_keys =
+        Enum.map(certs_keys, fn cert_key ->
+          Enum.reduce(ssl_files, Map.to_list(cert_key), &normalize_ssl_file(&1, &2))
+          |> Map.new()
+        end)
+
+      List.keystore(options, :certs_keys, 0, {:certs_keys, updated_certs_keys})
+    else
+      options
+    end
   end
 
   defp normalize_ssl_file(key, options) do

--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -208,7 +208,7 @@ defmodule Plug.SSL do
           |> Map.new()
         end)
 
-      List.keystore(options, :certs_keys, 0, {:certs_keys, updated_certs_keys})
+      Keyword.put(options, :certs_keys, updated_certs_keys)
     else
       options
     end


### PR DESCRIPTION
The `certs_keys` config key was added recently(ish) to the Erlang SSL stack.

https://www.erlang.org/doc/apps/ssl/ssl.html#t:cert_key_conf/0