### PR TITLE
link `Module.function/arity` to hexdocs in exception messages

### DIFF
--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -580,7 +580,7 @@ defmodule Plug.Debugger do
          {arity, ""} <- Integer.parse(arity),
          index when is_integer(index) <- rindex(function_path, "."),
          module <- String.slice(function_path, 0, index) |> String.split(".") |> Module.concat(),
-         function <- String.slice(function_path, (index + 1)..-1) |> String.to_atom() do
+         function <- String.slice(function_path, (index + 1)..-1//1) |> String.to_atom() do
       {:ok, module, function, arity}
     else
       _ -> :error

--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -575,16 +575,13 @@ defmodule Plug.Debugger do
   defp maybe_format_function_reference(text), do: h(text)
 
   def get_mfa(capture) do
-    with [function_path, arity] <- String.split(capture, "/"),
-         {arity, ""} <- Integer.parse(arity),
-         parts = String.split(function_path, "."),
-         {function_str, parts} <- List.pop_at(parts, -1),
-         module = Module.concat(parts),
-         function = String.to_existing_atom(function_str) do
-      {:ok, module, function, arity}
-    else
-      _ -> :error
-    end
+    [function_path, arity] = String.split(capture, "/")
+    {arity, ""} = Integer.parse(arity)
+    parts = String.split(function_path, ".")
+    {function_str, parts} = List.pop_at(parts, -1)
+    module = Module.safe_concat(parts)
+    function = String.to_existing_atom(function_str)
+    {:ok, module, function, arity}
   rescue
     _ -> :error
   end

--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -551,7 +551,11 @@ defmodule Plug.Debugger do
   end
 
   defp maybe_autolink(message) do
-    splitted = Regex.split(~r/`[A-Z][A-Za-z0-9_.]+\.[a-z][A-Za-z0-9_!?]*\/\d+`/, message, include_captures: true, trim: true)
+    splitted =
+      Regex.split(~r/`[A-Z][A-Za-z0-9_.]+\.[a-z][A-Za-z0-9_!?]*\/\d+`/, message,
+        include_captures: true,
+        trim: true
+      )
 
     Enum.map(splitted, &maybe_format_function_reference/1)
     |> IO.iodata_to_binary()

--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -578,22 +578,13 @@ defmodule Plug.Debugger do
   def get_mfa(capture) do
     with [function_path, arity] <- String.split(capture, "/"),
          {arity, ""} <- Integer.parse(arity),
-         index when is_integer(index) <- rindex(function_path, "."),
-         module <- String.slice(function_path, 0, index) |> String.split(".") |> Module.concat(),
-         function <- String.slice(function_path, (index + 1)..-1//1) |> String.to_atom() do
+         parts = String.split(function_path, "."),
+         {function_str, parts} <- List.pop_at(parts, -1),
+         module = Module.concat(parts),
+         function = String.to_atom(function_str) do
       {:ok, module, function, arity}
     else
       _ -> :error
-    end
-  end
-
-  defp rindex(string, pattern) do
-    string
-    |> String.reverse()
-    |> :binary.match(pattern)
-    |> case do
-      {index, _} -> String.length(string) - index - String.length(pattern)
-      :nomatch -> nil
     end
   end
 end

--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -569,7 +569,7 @@ defmodule Plug.Debugger do
     end
   end
 
-  defp maybe_format_function_reference(text), do: text
+  defp maybe_format_function_reference(text), do: h(text)
 
   defp function_reference?(text) do
     Regex.match?(~r/^[A-Z][A-Za-z0-9_.]+\.[a-z][A-Za-z0-9_!?]*\/\d+$/, text)

--- a/lib/plug/templates/debugger.html.eex
+++ b/lib/plug/templates/debugger.html.eex
@@ -884,7 +884,7 @@
                 <small>at <%= h method(@conn) %></small>
                 <small class="path"><%= h @conn.request_path %></small>
             </h5>
-            <code><pre class="exception-details-text"><%= h @message %></pre></code>
+            <code><pre class="exception-details-text"><%= @message %></pre></code>
         </header>
 
         <%= for %{label: label, encoded_handler: encoded_handler} <- @actions do %>

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,8 @@ defmodule Plug.MixProject do
         groups_for_extras: groups_for_extras(),
         source_ref: "v#{@version}",
         source_url: "https://github.com/elixir-plug/plug"
-      ]
+      ],
+      test_ignore_filters: [&String.starts_with?(&1, "test/fixtures/")]
     ]
   end
 

--- a/test/plug/adapters/test/conn_test.exs
+++ b/test/plug/adapters/test/conn_test.exs
@@ -161,13 +161,13 @@ defmodule Plug.Adapters.Test.ConnTest do
   end
 
   test "use existing conn.remote_ip if exists" do
-    conn_with_remote_ip = %Plug.Conn{conn(:get, "/") | remote_ip: {151, 236, 219, 228}}
+    conn_with_remote_ip = %{conn(:get, "/") | remote_ip: {151, 236, 219, 228}}
     child_conn = Plug.Adapters.Test.Conn.conn(conn_with_remote_ip, :get, "/", foo: "bar")
     assert child_conn.remote_ip == {151, 236, 219, 228}
   end
 
   test "use existing conn.port if exists" do
-    conn_with_port = %Plug.Conn{conn(:get, "/") | port: 4200}
+    conn_with_port = %{conn(:get, "/") | port: 4200}
     child_conn = Plug.Adapters.Test.Conn.conn(conn_with_port, :get, "/", foo: "bar")
     assert child_conn.port == 4200
   end

--- a/test/plug/debugger_test.exs
+++ b/test/plug/debugger_test.exs
@@ -609,4 +609,14 @@ defmodule Plug.DebuggerTest do
     assert conn.resp_body =~
              ~r(<a href="https://hexdocs.pm/plug/.*/Plug.Conn.html#send_resp/3" target="_blank">`Plug.Conn.send_resp/3`</a>)
   end
+
+  test "does not create new atoms" do
+    conn =
+      conn(:get, "/foo/bar")
+      |> put_req_header("accept", "text/html")
+      |> render([], fn -> raise "please use `NotExisting.not_existing_atom_for_test_does_not_create_new_atom/1` instead" end)
+
+    assert conn.resp_body =~ ~r(`NotExisting.not_existing_atom_for_test_does_not_create_new_atom/1`)
+    assert_raise ArgumentError, fn -> String.to_existing_atom("not_existing_atom_for_test_does_not_create_new_atom") end
+  end
 end

--- a/test/plug/debugger_test.exs
+++ b/test/plug/debugger_test.exs
@@ -599,4 +599,14 @@ defmodule Plug.DebuggerTest do
 
     assert conn.resp_body =~ "<span class=\"code\">  end</span>"
   end
+
+  test "links to hexdocs" do
+    conn =
+      conn(:get, "/foo/bar")
+      |> put_req_header("accept", "text/html")
+      |> render([], fn -> raise "please use `Plug.Conn.send_resp/3` instead" end)
+
+    assert conn.resp_body =~
+             ~r(<a href="https://hexdocs.pm/plug/.*/Plug.Conn.html#send_resp/3" target="_blank">`Plug.Conn.send_resp/3`</a>)
+  end
 end

--- a/test/plug/debugger_test.exs
+++ b/test/plug/debugger_test.exs
@@ -614,9 +614,15 @@ defmodule Plug.DebuggerTest do
     conn =
       conn(:get, "/foo/bar")
       |> put_req_header("accept", "text/html")
-      |> render([], fn -> raise "please use `NotExisting.not_existing_atom_for_test_does_not_create_new_atom/1` instead" end)
+      |> render([], fn ->
+        raise "please use `NotExisting.not_existing_atom_for_test_does_not_create_new_atom/1` instead"
+      end)
 
-    assert conn.resp_body =~ ~r(`NotExisting.not_existing_atom_for_test_does_not_create_new_atom/1`)
-    assert_raise ArgumentError, fn -> String.to_existing_atom("not_existing_atom_for_test_does_not_create_new_atom") end
+    assert conn.resp_body =~
+             ~r(`NotExisting.not_existing_atom_for_test_does_not_create_new_atom/1`)
+
+    assert_raise ArgumentError, fn ->
+      String.to_existing_atom("not_existing_atom_for_test_does_not_create_new_atom")
+    end
   end
 end


### PR DESCRIPTION
Idea by @Gazler

This is similar to ExDoc autolinking, but only works for the simple Elixir `Module.function/arity` format.

Before:
<img width="732" alt="image" src="https://github.com/user-attachments/assets/68918cf8-b578-45ed-afec-f8025f9760e4" />

After:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/7fb65846-5639-4b70-845b-e3f6e34b939e" />
