### PR TITLE
Add changelog to hexdocs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,6 +4,7 @@ defmodule Plug.MixProject do
   @version "1.17.0"
   @description "Compose web applications with functions"
   @xref_exclude [Plug.Cowboy, :ssl]
+  @source_url "https://github.com/elixir-plug/plug"
 
   def project do
     [
@@ -18,6 +19,7 @@ defmodule Plug.MixProject do
       consolidate_protocols: Mix.env() != :test,
       docs: [
         extras: [
+          "CHANGELOG.md",
           "README.md",
           "guides/https.md"
         ],
@@ -25,7 +27,7 @@ defmodule Plug.MixProject do
         groups_for_modules: groups_for_modules(),
         groups_for_extras: groups_for_extras(),
         source_ref: "v#{@version}",
-        source_url: "https://github.com/elixir-plug/plug"
+        source_url: @source_url
       ],
       test_ignore_filters: [&String.starts_with?(&1, "test/fixtures/")]
     ]
@@ -62,7 +64,10 @@ defmodule Plug.MixProject do
     %{
       licenses: ["Apache-2.0"],
       maintainers: ["Gary Rennie", "José Valim"],
-      links: %{"GitHub" => "https://github.com/elixir-plug/plug"},
+      links: %{
+        "Changelog" => "#{@source_url}/blob/main/CHANGELOG.md",
+        "GitHub" => @source_url
+      },
       files: ["lib", "mix.exs", "README.md", "CHANGELOG.md", "LICENSE", "src", ".formatter.exs"]
     }
   end


### PR DESCRIPTION
It's easier to read the changelog in hexdocs.pm and search for relevant details like depreciation item instead of switching between CHANGELOG.md in github.com and HTML documentation in hexdocs.pm.

![Screenshot from 2025-04-07 11-46-50](https://github.com/user-attachments/assets/70ddead0-9ff8-4324-9b98-409f9d4f44b7)
