### PR TITLE
Customize the Logger metadata key name

### DIFF
--- a/lib/plug/request_id.ex
+++ b/lib/plug/request_id.ex
@@ -47,11 +47,12 @@ defmodule Plug.RequestId do
 
           plug Plug.RequestId, assign_as: :plug_request_id
 
-    * `:log_as` - The name of the key that will be used to store the
+    * `:logger_metadata_key` - The name of the key that will be used to store the
       discovered or generated request id in `Logger` metadata. If not provided,
-      the request id will be stored as `:request_id`.
+      the request ID Logger metadata will be stored as `:request_id`. *Available
+      since v1.18.0*.
 
-          plug Plug.RequestId, log_as: :my_request_id
+          plug Plug.RequestId, logger_metadata_key: :my_request_id
 
   """
 
@@ -64,15 +65,15 @@ defmodule Plug.RequestId do
     {
       Keyword.get(opts, :http_header, "x-request-id"),
       Keyword.get(opts, :assign_as),
-      Keyword.get(opts, :log_as, :request_id)
+      Keyword.get(opts, :logger_metadata_key, :request_id)
     }
   end
 
   @impl true
-  def call(conn, {header, assign_as, log_as}) do
+  def call(conn, {header, assign_as, logger_metadata_key}) do
     request_id = get_request_id(conn, header)
 
-    Logger.metadata([{log_as, request_id}])
+    Logger.metadata([{logger_metadata_key, request_id}])
     conn = if assign_as, do: Conn.assign(conn, assign_as, request_id), else: conn
 
     Conn.put_resp_header(conn, header, request_id)

--- a/test/plug/request_id_test.exs
+++ b/test/plug/request_id_test.exs
@@ -82,6 +82,20 @@ defmodule Plug.RequestIdTest do
     assert res_request_id == meta_request_id
   end
 
+  test "adds the request id to Logger metadata with the given log key" do
+    request_id = "existingidthatislongenough"
+
+    conn =
+      conn(:get, "/")
+      |> put_req_header("x-request-id", request_id)
+      |> call(log_as: :plug_request_id)
+
+    [res_request_id] = get_resp_header(conn, "x-request-id")
+    meta_request_id = Logger.metadata()[:plug_request_id]
+    assert generated_request_id?(res_request_id)
+    assert res_request_id == meta_request_id
+  end
+
   defp generated_request_id?(request_id) do
     Regex.match?(~r/\A[A-Za-z0-9-_]+\z/, request_id)
   end

--- a/test/plug/request_id_test.exs
+++ b/test/plug/request_id_test.exs
@@ -88,7 +88,7 @@ defmodule Plug.RequestIdTest do
     conn =
       conn(:get, "/")
       |> put_req_header("x-request-id", request_id)
-      |> call(log_as: :plug_request_id)
+      |> call(logger_metadata_key: :plug_request_id)
 
     [res_request_id] = get_resp_header(conn, "x-request-id")
     meta_request_id = Logger.metadata()[:plug_request_id]


### PR DESCRIPTION
In certain scenarios we may want to use the `Plug.RequestID` plug multiple times with different headers or assigns.
While this is possible, the issue is that every call adds a `:request_id` key to the Logger metadata. When using the plug multiple times, the last call will override the metadata of the previous one.

```elixir
defmodule MyAppWeb.Endpoint do
  use Phoenix.Endpoint, otp_app: :my_app

  plug Plug.RequestId
  # This works, but overwrites the previous `:request_id` value in the logger metadata
  plug Plug.RequestId, http_header: "x-correlation-id", assign_as: :correlation_id
end
```

This commit adds a new `:log_as` option that allows users to customize how the request ID will be added to the logger metadata. If not provided, this option defaults to `:request_id` for backwards compatibility.

Previous code could be modified as:

```elixir
defmodule MyAppWeb.Endpoint do
  use Phoenix.Endpoint, otp_app: :my_app

  plug Plug.RequestId
  plug Plug.RequestId, http_header: "x-correlation-id", assign_as: :correlation_id, log_as: :correlation_id
end
```