### PR TITLE
docs: use up to date request ID format example

### DIFF
--- a/lib/plug/request_id.ex
+++ b/lib/plug/request_id.ex
@@ -5,7 +5,7 @@ defmodule Plug.RequestId do
   The generated request ID will be in the format:
 
   ```
-  uq8hs30oafhj5vve8ji5pmp7mtopc08f
+  GEBMr97eLMHtGWsAAAVj
   ```
 
   If a request ID already exists in a configured HTTP request header (see options below),


### PR DESCRIPTION
```elixir
binary = <<
  System.system_time(:nanosecond)::64,
  :erlang.phash2({node(), self()}, 16_777_216)::24,
  :erlang.unique_integer()::32
>>

Base.url_encode64(binary)
#=> "GEBMr97eLMHtGWsAAAVj"
```