### PR TITLE
fix: only response with html if client prefers media type

### DIFF
--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -300,24 +300,22 @@ defmodule Plug.Debugger do
   defp accepts_html?(_accept_header = []), do: false
 
   defp accepts_html?(_accept_header = [header | _]) do
-    parse_accect_header(header)
-    |> Enum.any?(&accept_html_media_type?/1)
-  end
-
-  defp parse_accect_header(accept_header) do
     accept_header
     |> String.split(",", trim: true)
     |> Enum.map(&Plug.Conn.Utils.media_type/1)
-    |> Enum.filter(&match?({:ok, _, _, _}, &1))
-    |> Enum.map(fn {:ok, type, subtype, params} ->
-      {type, subtype, Map.get(params, "q", 1)}
+    |> Enum.any?(fn
+      {:ok, type, subtype, params} ->
+        accept_html_media_type?(type, subtype, Map.get(params, "q", 1))
+
+      _ ->
+        false
     end)
   end
 
-  defp accept_html_media_type?({"text", "html", 1}), do: true
-  defp accept_html_media_type?({"text", "*", 1}), do: true
-  defp accept_html_media_type?({"*", "*", 1}), do: true
-  defp accept_html_media_type?({_type, _subtype, _q}), do: false
+  defp accept_html_media_type?("text", "html", 1), do: true
+  defp accept_html_media_type?("text", "*", 1), do: true
+  defp accept_html_media_type?("*", "*", 1), do: true
+  defp accept_html_media_type?(_type, _subtype, _q), do: false
 
   defp maybe_fetch_session(conn) do
     if conn.private[:plug_session_fetch] do

--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -300,7 +300,7 @@ defmodule Plug.Debugger do
   defp accepts_html?(_accept_header = []), do: false
 
   defp accepts_html?(_accept_header = [header | _]) do
-    accept_header
+    header
     |> String.split(",", trim: true)
     |> Enum.map(&Plug.Conn.Utils.media_type/1)
     |> Enum.any?(fn

--- a/lib/plug/debugger.ex
+++ b/lib/plug/debugger.ex
@@ -299,8 +299,25 @@ defmodule Plug.Debugger do
 
   defp accepts_html?(_accept_header = []), do: false
 
-  defp accepts_html?(_accept_header = [header | _]),
-    do: String.contains?(header, ["*/*", "text/*", "text/html"])
+  defp accepts_html?(_accept_header = [header | _]) do
+    parse_accect_header(header)
+    |> Enum.any?(&accept_html_media_type?/1)
+  end
+
+  defp parse_accect_header(accept_header) do
+    accept_header
+    |> String.split(",", trim: true)
+    |> Enum.map(&Plug.Conn.Utils.media_type/1)
+    |> Enum.filter(&match?({:ok, _, _, _}, &1))
+    |> Enum.map(fn {:ok, type, subtype, params} ->
+      {type, subtype, Map.get(params, "q", 1)}
+    end)
+  end
+
+  defp accept_html_media_type?({"text", "html", 1}), do: true
+  defp accept_html_media_type?({"text", "*", 1}), do: true
+  defp accept_html_media_type?({"*", "*", 1}), do: true
+  defp accept_html_media_type?({_type, _subtype, _q}), do: false
 
   defp maybe_fetch_session(conn) do
     if conn.private[:plug_session_fetch] do

--- a/test/plug/debugger_test.exs
+++ b/test/plug/debugger_test.exs
@@ -628,4 +628,31 @@ defmodule Plug.DebuggerTest do
       String.to_existing_atom("not_existing_atom_for_test_does_not_create_new_atom")
     end
   end
+
+  test "render markdown with text/html;q=0.5" do
+    conn =
+      conn(:get, "/")
+      |> put_req_header("accept", "text/html;q=0.5")
+      |> render([], fn -> raise "oops" end)
+
+    assert get_resp_header(conn, "content-type") == ["text/markdown; charset=utf-8"]
+  end
+
+  test "render markdown with text/*;q=0.5" do
+    conn =
+      conn(:get, "/")
+      |> put_req_header("accept", "text/*;q=0.5")
+      |> render([], fn -> raise "oops" end)
+
+    assert get_resp_header(conn, "content-type") == ["text/markdown; charset=utf-8"]
+  end
+
+  test "render markdown with */*;q=0.5" do
+    conn =
+      conn(:get, "/")
+      |> put_req_header("accept", "*/*;q=0.5")
+      |> render([], fn -> raise "oops" end)
+
+    assert get_resp_header(conn, "content-type") == ["text/markdown; charset=utf-8"]
+  end
 end


### PR DESCRIPTION
The previous implemtantion has quite basic and didn't account for the q parameter a client can add to an entry in the accept header. 

This would fail with HTTPie, which send requests with  "Accept: application/json, text/*;q=0.5". While one can argument that responding with HTML is in spec, it isn't a good DX.