### PR TITLE
Allow send_resp to be used without a body

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -590,10 +590,12 @@ defmodule Plug.Conn do
   ## Examples
 
       Plug.Conn.send_resp(conn, 404, "Not found")
+      Plug.Conn.send_resp(conn, 204)
 
   """
+  @spec send_resp(t, status) :: t | no_return
   @spec send_resp(t, status, body) :: t | no_return
-  def send_resp(%Conn{} = conn, status, body) do
+  def send_resp(%Conn{} = conn, status, body \\ "") do
     conn |> resp(status, body) |> send_resp()
   end
 

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -282,6 +282,16 @@ defmodule Plug.ConnTest do
     assert get_resp_cookies(conn)["hello"] == %{value: "world"}
   end
 
+  test "send_resp/2 sets the body to empty string" do
+    conn = conn(:get, "/foo")
+    assert conn.state == :unset
+    assert conn.resp_body == nil
+    conn = send_resp(conn, 204)
+    assert conn.status == 204
+    assert conn.resp_body == ""
+    assert conn.state == :sent
+  end
+
   test "send_resp/1 raises if the connection was unset" do
     conn = conn(:get, "/goo")
 

--- a/test/plug/telemetry_test.exs
+++ b/test/plug/telemetry_test.exs
@@ -8,9 +8,9 @@ defmodule Plug.TelemetryTest do
     use Plug.Builder
 
     plug Plug.Telemetry, event_prefix: [:pipeline], extra_options: :hello
-    plug :send_resp, 200
+    plug :send_response, 200
 
-    defp send_resp(conn, status) do
+    defp send_response(conn, status) do
       Plug.Conn.send_resp(conn, status, "Response")
     end
   end
@@ -26,13 +26,13 @@ defmodule Plug.TelemetryTest do
 
     plug Plug.Telemetry, event_prefix: [:crashing, :pipeline]
     plug :raise_error
-    plug :send_resp, 200
+    plug :send_response, 200
 
     defp raise_error(_conn, _) do
       raise "Crash!"
     end
 
-    defp send_resp(conn, status) do
+    defp send_response(conn, status) do
       Plug.Conn.send_resp(conn, status, "Response")
     end
   end


### PR DESCRIPTION
This will be useful for sending 204 No Content http status.
Instead of `send_resp(conn, :no_content, "")` we can now do `send_resp(conn, :no_content)`.

What do you guys think of it?

I find it more idiomatic to do this:
```ex
send_resp(conn, :no_content)
```
Instead of:
```ex
send_resp(conn, :no_content, "")
```