### PR TITLE
Rename Unprocessable Entity to Unprocessable Content

### DIFF
--- a/lib/plug/conn/status.ex
+++ b/lib/plug/conn/status.ex
@@ -5,6 +5,10 @@ defmodule Plug.Conn.Status do
 
   custom_statuses = Application.compile_env(:plug, :statuses, %{})
 
+  aliased_statuses = [
+    {422, :unprocessable_entity}
+  ]
+
   statuses = %{
     100 => "Continue",
     101 => "Switching Protocols",
@@ -49,7 +53,7 @@ defmodule Plug.Conn.Status do
     417 => "Expectation Failed",
     418 => "I'm a teapot",
     421 => "Misdirected Request",
-    422 => "Unprocessable Entity",
+    422 => "Unprocessable Content",
     423 => "Locked",
     424 => "Failed Dependency",
     425 => "Too Early",
@@ -118,6 +122,10 @@ defmodule Plug.Conn.Status do
   for {code, reason_phrase} <- statuses do
     atom = reason_phrase_to_atom.(reason_phrase)
     def code(unquote(atom)), do: unquote(code)
+  end
+
+  for {code, aliased_status} <- aliased_statuses do
+    def code(unquote(aliased_status)), do: unquote(code)
   end
 
   # This ensures that both the default and custom statuses will work

--- a/test/plug/conn/status_test.exs
+++ b/test/plug/conn/status_test.exs
@@ -13,10 +13,15 @@ defmodule Plug.Conn.StatusTest do
     assert Status.code(:ok) == 200
     assert Status.code(:non_authoritative_information) == 203
     assert Status.code(:not_found) == 404
+    assert Status.code(:unprocessable_content) == 422
   end
 
   test "code for custom status return the numeric code" do
     assert Status.code(:not_an_rfc_status_code) == 998
+  end
+
+  test "code for aliased statuses" do
+    assert Status.code(:unprocessable_entity) == 422
   end
 
   test "code with both a built_in and custom code return the numeric code" do


### PR DESCRIPTION
Since the 422 http status is actually Unprocessable Content and not Unprocessable Entity, we need to rename it.