### PR TITLE
Add keyword to init_test_session argument type

### DIFF
--- a/lib/plug/test.ex
+++ b/lib/plug/test.ex
@@ -282,7 +282,7 @@ defmodule Plug.Test do
   If the session has already been initialized, the new contents will be merged
   with the previous ones.
   """
-  @spec init_test_session(Conn.t(), %{optional(String.t() | atom) => any}) :: Conn.t()
+  @spec init_test_session(Conn.t(), %{optional(String.t() | atom) => any} | keyword) :: Conn.t()
   def init_test_session(conn, session) do
     conn =
       if conn.private[:plug_session_fetch] do


### PR DESCRIPTION
The unit tests actually use a keyword : https://github.com/elixir-plug/plug/blob/072236f85c380e631b141b5ff168dd94aa03cbc0/test/plug/session_test.exs#L156

And so that it matches https://github.com/phoenixframework/phoenix/blob/v1.7.21/lib/phoenix/test/conn_test.ex#L252-L253