### PR TITLE
Update send_chunked/2 docs to reflect streaming behaviour

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -510,7 +510,7 @@ defmodule Plug.Conn do
   the `chunk/2` function.
 
   HTTP/2 does not support chunking and will instead stream the response without a
-  transfer encoding. When using HTTP/1.1, the Cowboy adapter will stream the response
+  transfer encoding. When using HTTP/1.1, the underlying adapter will stream the response
   instead of emitting chunks if the `content-length` header has been set before calling
   `send_chunked/2`.
   """

--- a/lib/plug/conn/adapter.ex
+++ b/lib/plug/conn/adapter.ex
@@ -105,7 +105,12 @@ defmodule Plug.Conn.Adapter do
 
   @doc """
   Sends the given status, headers as the beginning of
-  a chunked response to the client.
+  a chunked response to the client. If the connection uses a
+  protocol (such as HTTP/2) which does not support chunked encoding,
+  the response should be sent in a streaming manner using the
+  protocol's framing method. Likewise if the passed headers include
+  a `content-length` header, the response should be streamed using
+  content length framing.
 
   Webservers are advised to return `nil` as the sent_body,
   since this function does not actually produce a body.


### PR DESCRIPTION
Hot on the tails of Bandit's support for this, update the docs to call out the behaviour on both the conn and the adapter 