### PR TITLE
Explicitly document http_only default value

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1656,7 +1656,7 @@ defmodule Plug.Conn do
       option will set both the _max-age_ and _expires_ cookie attributes. Unset
       by default, which means the browser will default to a [session cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_the_lifetime_of_a_cookie).
     * `:path` - the path the cookie applies to
-    * `:http_only` - when `false`, the cookie is accessible beyond HTTP
+    * `:http_only` - when `false`, the cookie is accessible beyond HTTP. Defaults to `true`
     * `:secure` - if the cookie must be sent only over https. Defaults
       to true when the connection is HTTPS
     * `:extra` - string to append to cookie. Use this to take advantage of


### PR DESCRIPTION
Today was the second or third time in the last 2 years I went searching through the code to confirm this will default to true. Perhaps I'm being overly paranoid, but this default is important for security reasons. The current language felt a little too ambiguous about what happens when omitted.