### PR TITLE
Use raw mode to delete files

### DIFF
--- a/lib/plug/upload.ex
+++ b/lib/plug/upload.ex
@@ -248,7 +248,7 @@ defmodule Plug.Upload do
   end
 
   defp delete_path({_pid, path}) do
-    :file.delete(path)
+    :file.delete(path, [:raw])
     :ok
   end
 end

--- a/lib/plug/upload/terminator.ex
+++ b/lib/plug/upload/terminator.ex
@@ -21,7 +21,7 @@ defmodule Plug.Upload.Terminator do
   end
 
   defp delete_path({_pid, path}) do
-    :file.delete(path)
+    :file.delete(path, [:raw])
     :ok
   end
 end


### PR DESCRIPTION
Just faster, minor change. Plug already uses raw mode in so many places, including `Upload`, I can assume we're not using any special filesystem here and raw mode just works (?).