### PR TITLE
add prefix option to RequestId

### DIFF
--- a/test/plug/request_id_test.exs
+++ b/test/plug/request_id_test.exs
@@ -7,6 +7,15 @@ defmodule Plug.RequestIdTest do
     Plug.RequestId.call(conn, Plug.RequestId.init(opts))
   end
 
+  test "generates new request id with prefix" do
+    conn = call(conn(:get, "/"), prefix: :myapp)
+    [res_request_id] = get_resp_header(conn, "x-request-id")
+    meta_request_id = Logger.metadata()[:request_id]
+    assert generated_request_id?(res_request_id)
+    assert res_request_id == meta_request_id
+    assert String.starts_with?(res_request_id, "myapp-")
+  end
+
   test "generates new request id if none exists" do
     conn = call(conn(:get, "/"), [])
     [res_request_id] = get_resp_header(conn, "x-request-id")


### PR DESCRIPTION
This PR adds a prefix option to Plug.RequestId, in a micro service architecture it can be helpful to append prefix to request id that a service generate them self, to differentiate them from all other request.