### PR TITLE
Make wss x-forwarded-proto work in all cases

### DIFF
--- a/lib/plug/rewrite_on.ex
+++ b/lib/plug/rewrite_on.ex
@@ -102,6 +102,9 @@ defmodule Plug.RewriteOn do
   defp put_scheme(conn, ["https"]),
     do: %{conn | scheme: :https}
 
+  defp put_scheme(conn, ["wss"]),
+    do: %{conn | scheme: :https}
+
   defp put_scheme(%{scheme: :https, port: 443} = conn, ["http"]),
     do: %{conn | scheme: :http, port: 80}
 


### PR DESCRIPTION
Follow up to #1302, which handled only one of two function heads reacting to "https" value.