### PR TITLE
Allow Plug.Session :key option to accept a 0-arity function

### DIFF
--- a/lib/plug/session.ex
+++ b/lib/plug/session.ex
@@ -26,7 +26,13 @@ defmodule Plug.Session do
   ## Options
 
     * `:store` - session store module (required);
-    * `:key` - session cookie key (required);
+    * `:key` - session cookie key (required); may be a 0-arity function,
+      evaluated at runtime on every request. Since browsers scope cookies
+      by domain only, not port, multiple apps running on the same host
+      can use this to avoid sharing session cookies:
+
+          key: fn -> "_my_app_\#{System.fetch_env!("PORT")}" end,
+
     * `:domain` - see `Plug.Conn.put_resp_cookie/4`;
     * `:max_age` - see `Plug.Conn.put_resp_cookie/4`;
     * `:path` - see `Plug.Conn.put_resp_cookie/4`;
@@ -69,10 +75,15 @@ defmodule Plug.Session do
     Conn.put_private(conn, :plug_session_fetch, fetch_session(config))
   end
 
+  defp resolve_key(key) when is_function(key, 0), do: key.()
+  defp resolve_key(key), do: key
+
   defp fetch_session(config) do
     %{store: store, store_config: store_config, key: key} = config
 
     fn conn ->
+      key = resolve_key(key)
+
       {sid, session} =
         if cookie = Plug.Conn.get_cookies(conn)[key] do
           store.get(conn, cookie, store_config)
@@ -133,8 +144,8 @@ defmodule Plug.Session do
     do: store.delete(conn, sid, store_config)
 
   defp put_cookie(value, conn, %{cookie_opts: cookie_opts, key: key}),
-    do: Conn.put_resp_cookie(conn, key, value, cookie_opts)
+    do: Conn.put_resp_cookie(conn, resolve_key(key), value, cookie_opts)
 
   defp delete_cookie(conn, %{cookie_opts: cookie_opts, key: key}),
-    do: Conn.delete_resp_cookie(conn, key, cookie_opts)
+    do: Conn.delete_resp_cookie(conn, resolve_key(key), cookie_opts)
 end

--- a/test/plug/session_test.exs
+++ b/test/plug/session_test.exs
@@ -198,4 +198,13 @@ defmodule Plug.SessionTest do
     assert get_session(conn, :other) == "other"
     assert get_session(conn, :bar) == "bar"
   end
+
+  test "accepts a function as key" do
+    conn = fetch_cookies(conn(:get, "/"))
+    opts = Plug.Session.init(store: ProcessStore, key: fn -> "foobar" end)
+    conn = conn |> Plug.Session.call(opts) |> fetch_session()
+    conn = put_session(conn, "foo", "bar")
+    conn = send_resp(conn, 200, "")
+    assert match?(%{"foobar" => %{value: _}}, get_resp_cookies(conn))
+  end
 end


### PR DESCRIPTION
Since browsers scope cookies by domain only, not port, multiple instances of the same app running on different ports share the same session cookie by default. This is a common issue in development, where you might run several instances simultaneously — for example, when using multiple git worktrees.

Allowing :key to accept a 0-arity function makes it possible to derive the cookie name from runtime configuration such as the port, so each instance gets its own isolated session without any workaround.

```elixir
if Application.compile_env(:my_app, :env) == :dev do
  plug Plug.Session,
    store: :cookie,
    key: fn -> "_my_app_#{System.fetch_env!("PORT")}" end,
    signing_salt: "..."
else
  plug Plug.Session,
    store: :cookie,
    key: "_my_app_key",
    signing_salt: "..."
end
```