### PR TITLE
Fix Elixir 1.20 compilation warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Plug.MixProject do
       package: package(),
       description: @description,
       name: "Plug",
-      xref: [exclude: @xref_exclude],
+      elixirc_options: [no_warn_undefined: @xref_exclude],
       consolidate_protocols: Mix.env() != :test,
       docs: [
         extras: [


### PR DESCRIPTION
Resolve compilation warnings in Elixir 1.20 by updating deprecated `xref` usage in mix.exs