### PR TITLE
upgrade_adapter/3 runs before_send callbacks

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1469,7 +1469,8 @@ defmodule Plug.Conn do
       when state in @unsent do
     case adapter.upgrade(payload, protocol, args) do
       {:ok, payload} ->
-        %{conn | adapter: {adapter, payload}, state: :upgraded}
+        conn = run_before_send(conn, :upgraded)
+        %{conn | adapter: {adapter, payload}}
 
       {:error, :not_supported} ->
         raise ArgumentError, "upgrade to #{protocol} not supported by #{inspect(adapter)}"

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -480,6 +480,15 @@ defmodule Plug.ConnTest do
     end)
   end
 
+  test "upgrade_adapter/3 runs before_send callbacks" do
+    conn =
+      conn(:get, "/foo")
+      |> register_before_send(&assign(&1, :ran_before_send, true))
+      |> upgrade_adapter(:supported, opt: :supported)
+
+    assert conn.assigns[:ran_before_send] == true
+  end
+
   test "chunk/2 raises if send_chunked/3 hasn't been called yet" do
     conn = conn(:get, "/")
 


### PR DESCRIPTION
> We should change [upgrade_adapter] to call the callback on :upgrade too. We already call it when :chunked and in other scenarios, so it is already the user's responsibility to check the state is something they can deal with. PRs welcome.

Fixes #1308.