### PR TITLE
Optimize Plug.Conn.Utils.validate_utf8!/3

### DIFF
--- a/lib/plug/conn/utils.ex
+++ b/lib/plug/conn/utils.ex
@@ -297,27 +297,33 @@ defmodule Plug.Conn.Utils do
   def validate_utf8!(binary, exception, context)
 
   def validate_utf8!(<<binary::binary>>, exception, context) do
-    do_validate_utf8!(binary, exception, context)
+    if byte_size(binary) < 12 do
+      do_validate_utf8_small!(binary, exception, context)
+    else
+      do_validate_utf8_swar!(binary, exception, context)
+    end
   end
 
-  defp do_validate_utf8!(<<w::56, b, rest::bits>>, exception, context)
+  # SWAR loop
+  defp do_validate_utf8_swar!(<<w::56, b, rest::bits>>, exception, context)
        when b <= 127 and ascii_swar?(w) do
-    do_validate_utf8!(rest, exception, context)
+    do_validate_utf8_swar!(rest, exception, context)
   end
 
-  defp do_validate_utf8!(<<b, rest::bits>>, exception, context) when b <= 127 do
-    do_validate_utf8!(rest, exception, context)
+  defp do_validate_utf8_swar!(rest, exception, context) do
+    do_validate_utf8_small!(rest, exception, context)
   end
 
-  defp do_validate_utf8!(<<_::utf8, rest::bits>>, exception, context) do
-    do_validate_utf8!(rest, exception, context)
+  # Small loop (identical to original character loop)
+  defp do_validate_utf8_small!(<<_::utf8, rest::bits>>, exception, context) do
+    do_validate_utf8_small!(rest, exception, context)
   end
 
-  defp do_validate_utf8!(<<byte, _::bits>>, exception, context) do
+  defp do_validate_utf8_small!(<<byte, _::bits>>, exception, context) do
     raise exception, "invalid UTF-8 on #{context}, got byte #{byte}"
   end
 
-  defp do_validate_utf8!(<<>>, _exception, _context) do
+  defp do_validate_utf8_small!(<<>>, _exception, _context) do
     :ok
   end
 

--- a/lib/plug/conn/utils.ex
+++ b/lib/plug/conn/utils.ex
@@ -321,7 +321,6 @@ defmodule Plug.Conn.Utils do
     :ok
   end
 
-
   ## Helpers
 
   defp strip_spaces("\r\n" <> t), do: strip_spaces(t)

--- a/lib/plug/conn/utils.ex
+++ b/lib/plug/conn/utils.ex
@@ -286,21 +286,39 @@ defmodule Plug.Conn.Utils do
         do: stripped
   end
 
+  # 56-bit SWAR guard: all 7 bytes are ASCII (< 128)
+  defguardp ascii_swar?(w)
+            when Bitwise.band(w, 0x80808080808080) == 0
+
   @doc """
   Validates the given binary is valid UTF-8.
   """
   @spec validate_utf8!(binary, module, binary) :: :ok | no_return
-  def validate_utf8!(binary, exception, context)
-
   def validate_utf8!(<<binary::binary>>, exception, context) do
-    case :unicode.characters_to_binary(binary) do
-      ^binary ->
-        :ok
-
-      {_, _, <<byte, _::binary>>} ->
-        raise exception, "invalid UTF-8 on #{context}, got byte #{byte}"
-    end
+    do_validate_utf8!(binary, exception, context)
   end
+
+  defp do_validate_utf8!(<<w::56, b, rest::binary>>, exception, context)
+       when b <= 127 and ascii_swar?(w) do
+    do_validate_utf8!(rest, exception, context)
+  end
+
+  defp do_validate_utf8!(<<b, rest::binary>>, exception, context) when b <= 127 do
+    do_validate_utf8!(rest, exception, context)
+  end
+
+  defp do_validate_utf8!(<<_::utf8, rest::binary>>, exception, context) do
+    do_validate_utf8!(rest, exception, context)
+  end
+
+  defp do_validate_utf8!(<<byte, _::binary>>, exception, context) do
+    raise exception, "invalid UTF-8 on #{context}, got byte #{byte}"
+  end
+
+  defp do_validate_utf8!(<<>>, _exception, _context) do
+    :ok
+  end
+
 
   ## Helpers
 

--- a/lib/plug/conn/utils.ex
+++ b/lib/plug/conn/utils.ex
@@ -294,24 +294,26 @@ defmodule Plug.Conn.Utils do
   Validates the given binary is valid UTF-8.
   """
   @spec validate_utf8!(binary, module, binary) :: :ok | no_return
+  def validate_utf8!(binary, exception, context)
+
   def validate_utf8!(<<binary::binary>>, exception, context) do
     do_validate_utf8!(binary, exception, context)
   end
 
-  defp do_validate_utf8!(<<w::56, b, rest::binary>>, exception, context)
+  defp do_validate_utf8!(<<w::56, b, rest::bits>>, exception, context)
        when b <= 127 and ascii_swar?(w) do
     do_validate_utf8!(rest, exception, context)
   end
 
-  defp do_validate_utf8!(<<b, rest::binary>>, exception, context) when b <= 127 do
+  defp do_validate_utf8!(<<b, rest::bits>>, exception, context) when b <= 127 do
     do_validate_utf8!(rest, exception, context)
   end
 
-  defp do_validate_utf8!(<<_::utf8, rest::binary>>, exception, context) do
+  defp do_validate_utf8!(<<_::utf8, rest::bits>>, exception, context) do
     do_validate_utf8!(rest, exception, context)
   end
 
-  defp do_validate_utf8!(<<byte, _::binary>>, exception, context) do
+  defp do_validate_utf8!(<<byte, _::bits>>, exception, context) do
     raise exception, "invalid UTF-8 on #{context}, got byte #{byte}"
   end
 

--- a/lib/plug/conn/utils.ex
+++ b/lib/plug/conn/utils.ex
@@ -293,19 +293,13 @@ defmodule Plug.Conn.Utils do
   def validate_utf8!(binary, exception, context)
 
   def validate_utf8!(<<binary::binary>>, exception, context) do
-    do_validate_utf8!(binary, exception, context)
-  end
+    case :unicode.characters_to_binary(binary) do
+      ^binary ->
+        :ok
 
-  defp do_validate_utf8!(<<_::utf8, rest::bits>>, exception, context) do
-    do_validate_utf8!(rest, exception, context)
-  end
-
-  defp do_validate_utf8!(<<byte, _::bits>>, exception, context) do
-    raise exception, "invalid UTF-8 on #{context}, got byte #{byte}"
-  end
-
-  defp do_validate_utf8!(<<>>, _exception, _context) do
-    :ok
+      {_, _, <<byte, _::binary>>} ->
+        raise exception, "invalid UTF-8 on #{context}, got byte #{byte}"
+    end
   end
 
   ## Helpers


### PR DESCRIPTION
Assisted by: Antigravity CLI : Gemini Flash 3.5

The optimized code is faster for valid input and the original code is faster for invalid input but invalid input should be rare in real world applications.



Bench:
```elixir
Mix.install([
  {:benchee, "~> 1.0"}
])

defmodule Original do
  def validate_utf8!(binary, exception, context) when is_binary(binary) do
    do_validate_utf8!(binary, exception, context)
  end

  defp do_validate_utf8!(<<_::utf8, rest::bits>>, exception, context) do
    do_validate_utf8!(rest, exception, context)
  end

  defp do_validate_utf8!(<<byte, _::bits>>, exception, context) do
    raise exception, "invalid UTF-8 on #{context}, got byte #{byte}"
  end

  defp do_validate_utf8!(<<>>, _exception, _context) do
    :ok
  end
end

defmodule Optimized do
  def validate_utf8!(binary, exception, context) when is_binary(binary) do
    case :unicode.characters_to_binary(binary) do
      ^binary ->
        :ok

      {_, _, <<byte, _::binary>>} ->
        raise exception, "invalid UTF-8 on #{context}, got byte #{byte}"
    end
  end
end

small_valid = "hello"
medium_valid = "hello world, this is a beautiful day! Elixir is awesome, and Plug is great."
large_valid = String.duplicate("Lorem ipsum dolor sit amet, consectetur adipiscing elit. ", 200)
invalid_string = "hello \xff world"

exception = RuntimeError
context = "test"

Benchee.run(
  %{
    "original" => fn input ->
      try do
        Original.validate_utf8!(input, exception, context)
      rescue
        _ -> :ok
      end
    end,
    "optimized" => fn input ->
      try do
        Optimized.validate_utf8!(input, exception, context)
      rescue
        _ -> :ok
      end
    end
  },
  inputs: %{
    "Small Valid" => small_valid,
    "Medium Valid" => medium_valid,
    "Large Valid" => large_valid,
    "Invalid" => invalid_string
  },
  time: 2,
  memory_time: 2
)
```

Benchmark results (noisy system):

```txt
Operating System: Linux
CPU Information: AMD Ryzen 7 8845HS w
Number of Available Cores: 16
Available memory: 54.72 GB
Elixir 1.20.0
Erlang 29.0.1
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 2 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: Invalid, Large Valid, Medium Valid, Small Valid
Estimated total run time: 48 s
Excluding outliers: false

##### With input Invalid #####
Name                ips        average  deviation         median         99th %
original         4.95 M      202.09 ns  ±2269.53%         180 ns         331 ns
optimized        2.10 M      475.80 ns  ±1401.32%         381 ns        1042 ns

Comparison:
original         4.95 M
optimized        2.10 M - 2.35x slower +273.71 ns

Memory usage statistics:

Name         Memory usage
original            336 B
optimized           456 B - 1.36x memory usage +120 B

**All measurements for memory usage were the same**

##### With input Large Valid #####
Name                ips        average  deviation         median         99th %
optimized      326.15 K        3.07 μs   ±212.89%        2.77 μs        5.64 μs
original        42.42 K       23.57 μs    ±40.51%       20.03 μs       43.54 μs

Comparison:
optimized      326.15 K
original        42.42 K - 7.69x slower +20.51 μs

Memory usage statistics:

Name         Memory usage
optimized             0 B
original             40 B - ∞ x memory usage +40 B

**All measurements for memory usage were the same**

##### With input Medium Valid #####
Name                ips        average  deviation         median         99th %
optimized       10.89 M       91.85 ns  ±8689.99%          60 ns         130 ns
original         6.15 M      162.55 ns  ±1687.46%         150 ns         291 ns

Comparison:
optimized       10.89 M
original         6.15 M - 1.77x slower +70.71 ns

Memory usage statistics:

Name         Memory usage
optimized             0 B
original             40 B - ∞ x memory usage +40 B

**All measurements for memory usage were the same**

##### With input Small Valid #####
Name                ips        average  deviation         median         99th %
optimized       18.57 M       53.84 ns  ±9579.56%          40 ns          61 ns
original        17.31 M       57.76 ns  ±6189.30%          41 ns          91 ns

Comparison:
optimized       18.57 M
original        17.31 M - 1.07x slower +3.92 ns

Memory usage statistics:

Name         Memory usage
optimized             0 B
original             40 B - ∞ x memory usage +40 B
```