### PR TITLE
Return 416 for invalid range requests in Plug.Static

### DIFF
--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -289,6 +289,7 @@ defmodule Plug.Static do
          {range_start, range_end} <- start_and_end(bytes, file_size) do
       send_range(conn, path, range_start, range_end, file_size, options)
     else
+      :unsatisfiable -> send_unsatisfiable_range(conn, file_size, options)
       _ -> send_entire_file(conn, path, options)
     end
   end
@@ -306,14 +307,17 @@ defmodule Plug.Static do
 
   defp start_and_end(range, file_size) do
     case Integer.parse(range) do
-      {first, "-"} when first >= 0 ->
+      {first, "-"} when first >= 0 and first < file_size ->
         {first, file_size - 1}
 
-      {first, "-" <> rest} when first >= 0 ->
+      {first, "-" <> rest} when first >= 0 and first < file_size ->
         case Integer.parse(rest) do
           {last, ""} when last >= first -> {first, min(last, file_size - 1)}
           _ -> :error
         end
+
+      {first, "-" <> _} when first >= file_size ->
+        :unsatisfiable
 
       _ ->
         :error
@@ -330,6 +334,14 @@ defmodule Plug.Static do
     conn
     |> put_resp_header("content-range", "bytes #{range_start}-#{range_end}/#{file_size}")
     |> send_file(206, path, range_start, length)
+    |> halt()
+  end
+
+  defp send_unsatisfiable_range(conn, file_size, options) do
+    conn
+    |> maybe_add_vary(options)
+    |> put_resp_header("content-range", "bytes */#{file_size}")
+    |> send_resp(416, "")
     |> halt()
   end
 

--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -298,6 +298,8 @@ defmodule Plug.Static do
     send_entire_file(conn, path, options)
   end
 
+  defp start_and_end(_range, 0), do: :error
+
   defp start_and_end("-" <> rest, file_size) do
     case Integer.parse(rest) do
       {last, ""} when last > 0 and last <= file_size -> {file_size - last, file_size - 1}

--- a/test/plug/static_test.exs
+++ b/test/plug/static_test.exs
@@ -502,6 +502,18 @@ defmodule Plug.StaticTest do
       end
     end
 
+    test "ignores range and serves the file when it is zero bytes" do
+      for range <- ["bytes=0-", "bytes=1-", "bytes=10-20"] do
+        conn =
+          conn(:get, "/public/fixtures/empty.txt", [])
+          |> put_req_header("range", range)
+          |> call()
+
+        assert conn.status == 200, "expected 200 for #{range}"
+        assert conn.resp_body == ""
+      end
+    end
+
     test "performs etag negotiation" do
       conn =
         conn(:get, "/public/fixtures/static.txt")

--- a/test/plug/static_test.exs
+++ b/test/plug/static_test.exs
@@ -468,6 +468,40 @@ defmodule Plug.StaticTest do
       assert get_resp_header(conn, "content-type") == ["text/plain"]
     end
 
+    test "returns 416 if range start is past the end of the file" do
+      conn =
+        conn(:get, "/public/fixtures/static.txt", [])
+        |> put_req_header("range", "bytes=10-20")
+        |> call()
+
+      assert conn.status == 416
+      assert conn.resp_body == ""
+      assert get_resp_header(conn, "content-range") == ["bytes */5"]
+      assert get_resp_header(conn, "accept-ranges") == ["bytes"]
+    end
+
+    test "returns 416 if open-ended range start is past the end of the file" do
+      conn =
+        conn(:get, "/public/fixtures/static.txt", [])
+        |> put_req_header("range", "bytes=10-")
+        |> call()
+
+      assert conn.status == 416
+      assert get_resp_header(conn, "content-range") == ["bytes */5"]
+    end
+
+    test "returns 416 if range start equals the file size" do
+      for range <- ["bytes=5-", "bytes=5-9"] do
+        conn =
+          conn(:get, "/public/fixtures/static.txt", [])
+          |> put_req_header("range", range)
+          |> call()
+
+        assert conn.status == 416, "expected 416 for #{range}"
+        assert get_resp_header(conn, "content-range") == ["bytes */5"]
+      end
+    end
+
     test "performs etag negotiation" do
       conn =
         conn(:get, "/public/fixtures/static.txt")


### PR DESCRIPTION
Currently, when receiving a range request, Plug.Static never validates that the range start falls within the file. 

When it receives a Range header where the first-byte position is at or past the end of the file, it produces a {start, end} pair where start > end. `send_range/6` then computes a negative length (range_end - range_start + 1) and forwards it to the adapter's send_file/6, which raises a RuntimeError.

This change adds logic to reject invalid ranges before trying to handle a negative length. It will now return a 416 + `Content-Range: bytes */<size>` instead of a 500, per RFC 9110 section 14.4.

I have also added a carve-out for empty files, similar to some other languages / libraries (e.g. Go's `net/http`), where the range parameter is ignored. This is because a) many clients attach a range header to all requests, and b) there's no valid range for an empty file, so we might as well just return the file they've requested.