### PR TITLE
Allow atom header keys in inform/3

### DIFF
--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1437,7 +1437,7 @@ defmodule Plug.Conn do
 
   defp adapter_inform(%Conn{adapter: {adapter, payload}}, status, headers) do
     for {key, value} <- headers do
-      validate_header_key_value!(key, value)
+      validate_header_key_value!(to_string(key), value)
     end
 
     adapter.inform(payload, status, headers)

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1436,9 +1436,12 @@ defmodule Plug.Conn do
   end
 
   defp adapter_inform(%Conn{adapter: {adapter, payload}}, status, headers) do
-    for {key, value} <- headers do
-      validate_header_key_value!(to_string(key), value)
-    end
+    headers =
+      for {key, value} <- headers do
+        key = to_string(key)
+        validate_header_key_value!(key, value)
+        {key, value}
+      end
 
     adapter.inform(payload, status, headers)
   end

--- a/lib/plug/conn.ex
+++ b/lib/plug/conn.ex
@@ -1436,12 +1436,9 @@ defmodule Plug.Conn do
   end
 
   defp adapter_inform(%Conn{adapter: {adapter, payload}}, status, headers) do
-    headers =
-      for {key, value} <- headers do
-        key = to_string(key)
-        validate_header_key_value!(key, value)
-        {key, value}
-      end
+    for {key, value} <- headers do
+      validate_header_key_value!(to_string(key), value)
+    end
 
     adapter.inform(payload, status, headers)
   end

--- a/test/plug/conn_test.exs
+++ b/test/plug/conn_test.exs
@@ -468,6 +468,11 @@ defmodule Plug.ConnTest do
     end
   end
 
+  test "inform/3 accepts atom header keys (e.g. for websocket upgrades)" do
+    conn = conn(:get, "/foo") |> inform(101, [{:upgrade, "websocket"}, {:connection, "Upgrade"}])
+    assert {101, [{:upgrade, "websocket"}, {:connection, "Upgrade"}]} in sent_informs(conn)
+  end
+
   test "inform!/3 performs an informational request" do
     conn = conn(:get, "/foo") |> inform!(103, [{"link", "</style.css>; rel=preload; as=style"}])
     assert {103, [{"link", "</style.css>; rel=preload; as=style"}]} in sent_informs(conn)


### PR DESCRIPTION
Hello plug team!

I've got an issue after upgrading plug, latest plug with latest bandit (1.12.0):

```elixir
  ** (ArgumentError) errors were found at the given arguments:
    * 1st argument: not a binary
      (stdlib 7.3) :binary.match(:upgrade, [":", "\n", "\r", <<0>>])
      (plug 1.20.0) lib/plug/conn.ex:1994: Plug.Conn.validate_header_key_value!/2
      (plug 1.20.0) lib/plug/conn.ex:1440: anonymous fn/2 in Plug.Conn.adapter_inform/3
      (plug 1.20.0) lib/plug/conn.ex:1393: Plug.Conn.inform/3
      (bandit 1.12.0) lib/bandit/websocket/handshake.ex:28: Bandit.WebSocket.Handshake.do_handshake/3
      (bandit 1.12.0) lib/bandit/pipeline.ex:150: Bandit.Pipeline.maybe_upgrade!/1
```

Bandit websocket handshake calls `Plug.Conn.inform(conn, 101, [{:upgrade, "websocket"}, ...])`, passing the header key as an atom. Newest plug on `validate_header_key_value!/2` calls `:binary.match/2` on the key without coercion to binary, so atoms blow up.

Thank you!