### PR TITLE
Optimize path splitting

### DIFF
--- a/lib/plug/adapters/test/conn.ex
+++ b/lib/plug/adapters/test/conn.ex
@@ -227,8 +227,7 @@ defmodule Plug.Adapters.Test.Conn do
   defp split_path(nil), do: []
 
   defp split_path(path) do
-    segments = :binary.split(path, "/", [:global])
-    for segment <- segments, segment != "", do: segment
+    :binary.split(path, "/", [:global, :trim_all])
   end
 
   @already_sent {:plug_conn, :sent}

--- a/lib/plug/conn/adapter.ex
+++ b/lib/plug/conn/adapter.ex
@@ -52,8 +52,7 @@ defmodule Plug.Conn.Adapter do
   end
 
   defp split_path(path) do
-    segments = :binary.split(path, "/", [:global])
-    for segment <- segments, segment != "", do: segment
+    :binary.split(path, "/", [:global, :trim_all])
   end
 
   @doc """

--- a/lib/plug/router/utils.ex
+++ b/lib/plug/router/utils.ex
@@ -278,7 +278,7 @@ defmodule Plug.Router.Utils do
 
   """
   def split(bin) do
-    for segment <- String.split(bin, "/"), segment != "", do: segment
+    :binary.split(bin, "/", [:global, :trim_all])
   end
 
   @deprecated "Use Plug.forward/4 instead"


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT 5.6 Sol

Less code, ~20% faster, uses half the memory.

Bench:
```elixir
Mix.install([:benchee])

paths = [
  "/",
  "/health",
  "/api/v1/users/42",
  "/api/v1/users/42/profile",
  "/oauth/callback/github",
  "/assets/app-3f2a1c9.js",
  "/images/products/2026/08/widget-large.webp",
  "/de/products/electronics/wireless-headphones",
  "/organizations/acme/projects/plug/pull_requests/123/files",
  "/.well-known/acme-challenge/7f86c2d1",
  "/api//v1/orders/123/"
]

split_and_filter = fn path ->
  segments = :binary.split(path, "/", [:global])
  for segment <- segments, segment != "", do: segment
end

split_with_trim = fn path ->
  :binary.split(path, "/", [:global, :trim_all])
end

Benchee.run(
  %{
    "split + filter (before)" => fn -> Enum.map(paths, split_and_filter) end,
    "split with trim_all (after)" => fn -> Enum.map(paths, split_with_trim) end
  },
  time: 3,
  warmup: 1,
  memory_time: 1,
  reduction_time: 1,
  pre_check: :all_same
)
```

Results:
```txt
Operating System: Linux
CPU Information: AMD Ryzen 7 8845HS w
Number of Available Cores: 16
Available memory: 54.72 GB
Elixir 1.20.3
Erlang 29.0.5
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 1 s
time: 3 s
memory time: 1 s
reduction time: 1 s
parallel: 1
inputs: none specified
Estimated total run time: 12 s
Excluding outliers: false

Benchmarking split + filter (before) ...
Benchmarking split with trim_all (after) ...
Calculating statistics...
Formatting results...

Name                                  ips        average  deviation         median         99th %
split with trim_all (after)      555.38 K        1.80 μs   ±323.04%        1.73 μs        2.30 μs
split + filter (before)          380.62 K        2.63 μs   ±251.43%        2.48 μs        4.76 μs

Comparison: 
split with trim_all (after)      555.38 K
split + filter (before)          380.62 K - 1.46x slower +0.83 μs

Memory usage statistics:

Name                           Memory usage
split with trim_all (after)         1.29 KB
split + filter (before)             2.89 KB - 2.24x memory usage +1.60 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                        Reduction count
split with trim_all (after)              62
split + filter (before)                 282 - 4.55x reduction count +220

**All measurements for reduction count were the same**
```