### PR TITLE
Simplify SSL password normalization

### DIFF
--- a/lib/plug/ssl.ex
+++ b/lib/plug/ssl.ex
@@ -173,7 +173,7 @@ defmodule Plug.SSL do
     |> validate_ciphers()
     |> normalize_ssl_files()
     |> normalize_certs_keys_ssl_files()
-    |> convert_to_charlist()
+    |> normalize_password()
     |> configure_managed_tls()
     |> set_secure_defaults()
   catch
@@ -258,14 +258,12 @@ defmodule Plug.SSL do
     end
   end
 
-  defp convert_to_charlist(options) do
-    Enum.reduce([:password], options, fn key, acc ->
-      if value = acc[key] do
-        List.keystore(acc, key, 0, {key, to_charlist(value)})
-      else
-        acc
-      end
-    end)
+  defp normalize_password(options) do
+    if password = options[:password] do
+      List.keystore(options, :password, 0, {:password, to_charlist(password)})
+    else
+      options
+    end
   end
 
   defp set_secure_defaults(options) do

--- a/test/plug/ssl_test.exs
+++ b/test/plug/ssl_test.exs
@@ -104,6 +104,14 @@ defmodule Plug.SSLTest do
       assert {:cert, "ghijkl"} in opts
     end
 
+    test "normalizes truthy passwords and preserves false" do
+      assert {:ok, opts} = configure(key: "abcdef", cert: "ghijkl", password: "cowboy")
+      assert opts[:password] == ~c"cowboy"
+
+      assert {:ok, opts} = configure(key: "abcdef", cert: "ghijkl", password: false)
+      assert opts[:password] == false
+    end
+
     test "fails to configure if keyfile and certfile aren't absolute paths and otp_app is missing" do
       assert {:error, message} = configure([:inet6, keyfile: "abcdef", certfile: "ghijkl"])
       assert message == "the :otp_app option is required when setting relative SSL certfiles"


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT 5.6 Sol

- Removes redundant `Enum.reduce` call.
- Renames function to mirror behavior
- Adds a test for this behavior 