### PR TITLE
Optimize static encoding negotiation

### DIFF
--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -449,11 +449,10 @@ defmodule Plug.Static do
   end
 
   defp accept_encoding?(conn, encoding) do
-    encoding? = &String.contains?(&1, [encoding, "*"])
-
-    Enum.any?(get_req_header(conn, "accept-encoding"), fn accept ->
-      accept |> Plug.Conn.Utils.list() |> Enum.any?(encoding?)
-    end)
+    Enum.any?(
+      get_req_header(conn, "accept-encoding"),
+      &String.contains?(&1, [encoding, "*"])
+    )
   end
 
   defp maybe_add(list, key, value, true), do: list ++ [{key, value}]

--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -449,10 +449,8 @@ defmodule Plug.Static do
   end
 
   defp accept_encoding?(conn, encoding) do
-    Enum.any?(
-      get_req_header(conn, "accept-encoding"),
-      &String.contains?(&1, [encoding, "*"])
-    )
+    encoding? = &String.contains?(&1, [encoding, "*"])
+    Enum.any?(get_req_header(conn, "accept-encoding"), encoding?)
   end
 
   defp maybe_add(list, key, value, true), do: list ++ [{key, value}]


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT 5.6 Sol

`any?(list(header), &contains?(&1, encoding))` 
is equivalent to 
`contains?(header, encoding)`